### PR TITLE
feat: add WC2 Peasant (PT-BR) sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -1883,6 +1883,43 @@
       "updated": "2026-02-12"
     },
     {
+      "name": "wc2_peasant_pt-br",
+      "display_name": "WC2 Peasant (PT-BR)",
+      "version": "1.0.0",
+      "description": "Human Peasant voice lines from WarCraft II dubbed in Brazilian Portuguese",
+      "author": { "name": "Lucas Oliveira", "github": "lucaspwo" },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "pt-BR",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 18,
+      "total_size_bytes": 199836,
+      "source_repo": "lucaspwo/openpeon-wc2-peasant-pt-br",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "7e111c1f860576cc6e0041def63a9e19734262a22c9b91b5cbb4dc4fb68b30cc",
+      "tags": [
+        "gaming",
+        "warcraft",
+        "blizzard",
+        "rts"
+      ],
+      "preview_sounds": [
+        "ReadyToServe.mp3",
+        "WorkComplete.mp3"
+      ],
+      "added": "2026-02-13",
+      "updated": "2026-02-13"
+    },
+    {
       "name": "wc2_sapper",
       "display_name": "WC2 Goblin Sappers",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary
- Adds Human Peasant voice lines from WarCraft II dubbed in Brazilian Portuguese as a new community sound pack
- 18 sound files across all 7 CESP categories

## Categories
| Category | Sounds |
|----------|--------|
| session.start | "À sua disposição!" , "Sim?", "Meu mestre?", "O que é isso?", "Alô?" |
| task.acknowledge | "Okay", "Certo", "Tudo bem", "Sim meu mestre" |
| task.complete | "Missão cumprida!" |
| task.error | *Attack sound effect* |
| input.required | "Sim?", "Meu mestre?", "O que é isso?", "Alô?" |
| resource.limit | *Attack sound effect* |
| user.spam | "O que?", "Ahn-hã?", "Agora o que é?", "Mais trabalho?", "Me deixa em paz!", "Não quero isso!", "Não estou escutando!" |

## Checklist
- [x] `openpeon.json` manifest follows CESP v1.0 format
- [x] All 7 categories present
- [x] All referenced sound files exist in `sounds/`
- [x] Audio files are MP3, under 1 MB each (total ~195 KB)
- [x] Entry added to `index.json` in alphabetical order
- [x] `trust_tier` set to `community`
- [x] `manifest_sha256` computed and included
- [x] Source repo is publicly accessible: [lucaspwo/openpeon-wc2-peasant-pt-br](https://github.com/lucaspwo/openpeon-wc2-peasant-pt-br)
- [x] Tagged release `v1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)