### PR TITLE
Add Deadpool (2016) sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -398,6 +398,46 @@
       "updated": "2026-02-13"
     },
     {
+      "name": "deadlock_dynamo",
+      "display_name": "Dynamo (Deadlock)",
+      "version": "1.0.0",
+      "description": "Dynamo voice pack from Valve's Deadlock",
+      "author": {
+        "name": "mwaterman29",
+        "github": "mwaterman29"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 48,
+      "total_size_bytes": 1038668,
+      "source_repo": "mwaterman29/openpeon-deadlock-dynamo",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "c1c983029329cf6e419086be004e3d4f4ccff2a7feefabfaf2eb49dac704d2de",
+      "tags": [
+        "gaming",
+        "deadlock",
+        "valve",
+        "moba"
+      ],
+      "preview_sounds": [
+        "dynamo_select_06.mp3",
+        "dynamo_ping_good_job_01.mp3"
+      ],
+      "added": "2026-02-13",
+      "updated": "2026-02-13"
+    },
+    {
       "name": "deadpool",
       "display_name": "Deadpool (2016)",
       "version": "1.0.0",
@@ -437,46 +477,6 @@
       ],
       "added": "2026-02-14",
       "updated": "2026-02-14"
-    },
-    {
-      "name": "deadlock_dynamo",
-      "display_name": "Dynamo (Deadlock)",
-      "version": "1.0.0",
-      "description": "Dynamo voice pack from Valve's Deadlock",
-      "author": {
-        "name": "mwaterman29",
-        "github": "mwaterman29"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 48,
-      "total_size_bytes": 1038668,
-      "source_repo": "mwaterman29/openpeon-deadlock-dynamo",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "c1c983029329cf6e419086be004e3d4f4ccff2a7feefabfaf2eb49dac704d2de",
-      "tags": [
-        "gaming",
-        "deadlock",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "dynamo_select_06.mp3",
-        "dynamo_ping_good_job_01.mp3"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
     },
     {
       "name": "dota2_axe",


### PR DESCRIPTION
## Summary
- Adds **Deadpool (2016)** sound pack with 35 audio clips featuring Ryan Reynolds' iconic one-liners
- All 7 peon-ping categories covered (5 clips each): `session.start`, `task.acknowledge`, `task.complete`, `task.error`, `input.required`, `resource.limit`, `user.spam`
- Source repo: [xtrimsystems/peon-ping-deadpool](https://github.com/xtrimsystems/peon-ping-deadpool) (tagged `v1.0.0`)

## Highlights
- **session.start**: "Maximum effort.", "Cue the music.", "Captain Deadpool..."
- **task.error**: "I think we can all agree that shit just went sideways", "Negasonic Teenage... What the shit?"
- **user.spam**: "Motherfucker, you're the world's worst friend.", "Bad Deadpool."

🤖 Generated with [Claude Code](https://claude.com/claude-code)