### PR TITLE
feat: add WC3 Human Peasant (PT-BR) sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -2251,6 +2251,46 @@
       ],
       "added": "2026-02-12",
       "updated": "2026-02-12"
+    },
+    {
+      "name": "wc3_peasant_pt-br",
+      "display_name": "WC3 Human Peasant (PT-BR)",
+      "version": "1.0.0",
+      "description": "Human Peasant voice lines from WarCraft III dubbed in Brazilian Portuguese",
+      "author": {
+        "name": "Lucas Oliveira",
+        "github": "lucaspwo"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "pt-BR",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 21,
+      "total_size_bytes": 364120,
+      "source_repo": "lucaspwo/open-peon-war3PT_BR",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "e245be2eb0a9a4cd624edbd2a70efc8cb00d2978968df2e0c835d8835ed9215f",
+      "tags": [
+        "gaming",
+        "warcraft",
+        "blizzard",
+        "rts"
+      ],
+      "preview_sounds": [
+        "PeasantReady1.mp3",
+        "PeasantBuildingComplete1.mp3"
+      ],
+      "added": "2026-02-14",
+      "updated": "2026-02-14"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds `wc3_peasant_pt-br` community sound pack with 21 Brazilian Portuguese voice lines from the WarCraft III human peasant
- All 7 CESP categories populated, following the same sound-to-category mapping as the official English `peasant` pack
- 3 bonus PT-BR exclusive sounds: `PeasantBuildingComplete1` (task.complete), `PeasantCannotBuildThere1` (task.error), `PeasantWarcry1` (resource.limit)

## Pack details
| Field | Value |
|---|---|
| Name | `wc3_peasant_pt-br` |
| Language | `pt-BR` |
| Version | `1.0.0` |
| Unique sounds | 21 |
| Total size | ~364 KB |
| Source repo | [lucaspwo/open-peon-war3PT_BR](https://github.com/lucaspwo/open-peon-war3PT_BR) |
| License | CC-BY-NC-4.0 |

## Category breakdown
| Category | Count | Sounds |
|---|---|---|
| `session.start` | 3 | Ready1, What1, What2 |
| `task.acknowledge` | 6 | Yes1-4, YesAttack1-2 |
| `task.complete` | 5 | Ready1, Yes1, Yes3, What3, BuildingComplete1 |
| `task.error` | 3 | YesAttack3-4, CannotBuildThere1 |
| `input.required` | 4 | What1-4 |
| `resource.limit` | 2 | YesAttack4, Warcry1 |
| `user.spam` | 5 | Pissed1-5 |

## Checklist
- [x] Source repo is public
- [x] `openpeon.json` follows CESP v1.0
- [x] Release tagged `v1.0.0`
- [x] `manifest_sha256` matches `openpeon.json`
- [x] All audio files are MP3 at 64 kbps
- [x] Entry placed in alphabetical order in `index.json`
- [x] License: CC-BY-NC-4.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)