### PR TITLE
fix: bump wc3_peasant_pt-br to v1.0.1

### DIFF
--- a/index.json
+++ b/index.json
@@ -2255,7 +2255,7 @@
     {
       "name": "wc3_peasant_pt-br",
       "display_name": "WC3 Human Peasant (PT-BR)",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Human Peasant voice lines from WarCraft III dubbed in Brazilian Portuguese",
       "author": {
         "name": "Lucas Oliveira",
@@ -2276,9 +2276,9 @@
       "sound_count": 21,
       "total_size_bytes": 364120,
       "source_repo": "lucaspwo/open-peon-war3PT_BR",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": ".",
-      "manifest_sha256": "e245be2eb0a9a4cd624edbd2a70efc8cb00d2978968df2e0c835d8835ed9215f",
+      "manifest_sha256": "fbe43123e4c5a1e730c2245799b9942a347678e025341d7f955e92ac101a12e6",
       "tags": [
         "gaming",
         "warcraft",


### PR DESCRIPTION
## Summary
- Bumps `wc3_peasant_pt-br` from v1.0.0 to v1.0.1
- Fixes pack `name` field in `openpeon.json` that didn't match the registry entry (`wc3_human_peasant_pt-br` → `wc3_peasant_pt-br`)
- Updates `source_ref`, `manifest_sha256` accordingly

## Changes
| Field | Before | After |
|---|---|---|
| `version` | `1.0.0` | `1.0.1` |
| `source_ref` | `v1.0.0` | `v1.0.1` |
| `manifest_sha256` | `e245be2e...` | `fbe43123...` |

Source: [lucaspwo/open-peon-war3PT_BR@v1.0.1](https://github.com/lucaspwo/open-peon-war3PT_BR/releases/tag/v1.0.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)