### PR TITLE
Adding Warcraft III package for the Undead Acolyte in Spanish

### DIFF
--- a/index.json
+++ b/index.json
@@ -65,7 +65,7 @@
       "sound_count": 29,
       "total_size_bytes": 2197202,
       "source_repo": "lurecas/openpeon-w3-acolyte-es",
-      "source_ref": "v1.0.2",
+      "source_ref": "1.0.2",
       "source_path": "acolyte_es",
       "manifest_sha256": "8a08bb9bdfadbb3a24601c51b4338c3fe0a5beba07c7ad59ba6354b60815cb18",
       "tags": [


### PR DESCRIPTION
## Summary
- Adds `acolyte_es` community sound pack with Warcraft III Undead Acolyte Spanish voice lines, following the two available `acolyte` packs available in the `og-packs` repository.
- All 7 CESP categories are populated
- Includes transcribed labels and SHA-256 hashes in `openpeon.json`
- For the `resource.limit` section, I took a couple of sounds from the Hero Lich, that looks pretty similar

## Pack details
| Field | Value |
|---|---|
| Name | `acolyte_es` |
| Language | `es` |
| Version | `1.0.0` |
| Sound entries | 29 |
| Unique audio files | 23 |
| Total size | 2,190,436 bytes |
| Source repo | [lurecas/openpeon-w3-acolyte-es](https://github.com/lurecas/openpeon-w3-acolyte-es) |
| License | CC-BY-NC-4.0 |

## Checklist
- [x] Source repo is public
- [x] `openpeon.json` follows CESP v1.0
- [x] `manifest_sha256` matches current `openpeon.json`
- [x] Entry added in alphabetical order in `index.json`
- [x] License declared
