### PR TITLE
Add Dobby the House-Elf sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -716,6 +716,43 @@
       "updated": "2026-02-14"
     },
     {
+      "name": "dobby",
+      "display_name": "Dobby the House-Elf",
+      "version": "1.0.0",
+      "description": "Dobby is here to help! A house-elf themed sound pack for OpenCode featuring Dobby from Harry Potter.",
+      "author": {
+        "name": "johmara",
+        "github": "johmara"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.complete",
+        "task.error",
+        "input.required"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 6,
+      "total_size_bytes": 2523948,
+      "source_repo": "johmara/openpeon-dobby",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "1e96f9b91fec1b71ce0516900b12d9ec8e27c029f46a7589888fcdefc3e0399b",
+      "tags": [
+        "movie",
+        "harry-potter",
+        "house-elf",
+        "fantasy"
+      ],
+      "preview_sounds": [
+        "sounds/dobby-hello.wav",
+        "sounds/dobby-done.wav"
+      ],
+      "added": "2026-02-17",
+      "updated": "2026-02-17"
+    },
+    {
       "name": "dota2_axe",
       "display_name": "Axe (Dota 2)",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary
This PR adds the Dobby the House-Elf sound pack to the OpenPeon registry.

**Dobby is here to help!** This pack features 6 curated voice clips from Dobby in the Harry Potter films, perfect for making your coding sessions more magical.

## Pack Details
- **Name**: dobby
- **Display Name**: Dobby the House-Elf
- **Version**: 1.0.0
- **Author**: @johmara
- **Repository**: https://github.com/johmara/openpeon-dobby
- **License**: CC-BY-NC-4.0
- **Language**: English
- **Trust Tier**: community

## Technical Details
- **Sound Count**: 6 clips
- **Total Size**: 2.52 MB
- **Audio Format**: 44100 Hz, 16-bit PCM, stereo WAV
- **Manifest SHA256**: `1e96f9b91fec1b71ce0516900b12d9ec8e27c029f46a7589888fcdefc3e0399b`

## Categories Covered
- session.start (2 clips)
- task.complete (1 clip)
- task.error (1 clip)
- input.required (2 clips)

## Sample Clips
- "Dobby has come to help!" (session.start)
- "Dobby is done!" (task.complete)
- "Dobby has difficulty with this" (task.error)
- "Dobby understands!" (input.required)

## Quality Assurance
✅ All clips extracted from official Harry Potter media
✅ Proper audio format (44100 Hz, 16-bit PCM)
✅ SHA256 hashes verified in openpeon.json
✅ Repository tagged with v1.0.0 release
✅ JSON validated successfully

## Note
⚠️ The repository is currently **private** and will be made **public** before this PR is merged to ensure the pack is accessible to all users.