### PR TITLE
feat: add Petite Speaki voice pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -2593,7 +2593,7 @@
       "source_repo": "CJNA/peon-ping-speaki",
       "source_ref": "v1.0.0",
       "source_path": "speaki",
-      "manifest_sha256": "335fd7d3cd5dc82eec0da459b80893752ecd63ab9ce2dc299f28d4e607b237f8",
+      "manifest_sha256": "e7d1a1cbd02e04143e8f0029863b67caaf074d86f7da42b9273846773f2d4822",
       "tags": [
         "gaming",
         "trickcal",


### PR DESCRIPTION
## Summary

- Adds **Petite Speaki** voice pack to the OpenPeon registry
- Korean character from [Trickcal Chibi Go](https://www.trickcal.com/) by EPIDGames / Bilibili
- 13 sounds across all 7 CESP categories
- Source: [`CJNA/peon-ping-speaki`](https://github.com/CJNA/peon-ping-speaki) @ `v1.0.0`

**Who is Speaki?** Watch here: [ｽﾋﾟｷMADでよく使われるボイス集](https://www.youtube.com/watch?v=SYacnl6MpSA)

![Petite Speaki](https://github.com/CJNA/peon-ping-speaki/blob/feat/speaki-pack/speaki/avatar.jpg?raw=true)

### Pack details

| Field | Value |
|-------|-------|
| Name | `speaki` |
| Display name | Petite Speaki |
| Language | Korean |
| Sound count | 13 |
| Total size | ~1.1 MB |
| License | CC-BY-NC-4.0 |
| Trust tier | community |

🤖 Generated with [Claude Code](https://claude.com/claude-code)