### PR TITLE
Add hal_2001 (HAL 9000 - 2001: A Space Odyssey) sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -1294,6 +1294,7 @@
       "total_size_bytes": 721994,
       "source_repo": "jquintus/openpeon-hal-2001",
       "source_ref": "v1.0.0",
+      "source_path": ".",
       "manifest_sha256": "984aa115db965f6a8eedfad06757bf69060a501dc8b5a28092ddc3431ddbf228",
       "tags": [
         "sci-fi",


### PR DESCRIPTION
## Summary

- Adds the `hal_2001` community pack to the registry
- 17 sound clips from HAL 9000 in *2001: A Space Odyssey*
- Covers categories: `session.start`, `task.acknowledge`, `task.complete`, `task.error`, `input.required`, `user.spam`
- Source: https://github.com/jquintus/openpeon-hal-2001 @ `v1.0.0`

## Test plan

- [ ] Verify `index.json` entry is valid against `schema/registry-v1.schema.json`
- [ ] Confirm `source_repo` and `source_ref` resolve to a public repo with a valid `openpeon.json`
- [ ] Confirm `manifest_sha256` matches the `openpeon.json` in the source repo
- [ ] Confirm all 17 sound files are present in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)