### PR TITLE
Add Omar Little (The Wire) sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -1641,7 +1641,7 @@
       "source_repo": "taylan/openpeon-omar",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "dc2bfd3b5df697897cfc392d1eda58673fa3ad112f7e2f1d80f80b40dbf0ff4f",
+      "manifest_sha256": "036fd2b2000c8a7548b77e5f036a884d21b01c3892a483fa815cc438dd1a9722",
       "tags": [
         "tv",
         "the-wire",


### PR DESCRIPTION
## Summary

- Adds **Omar Little (The Wire)** sound pack to the registry
- 32 unique sounds across all 9 CESP categories
- Source repo: [taylan/openpeon-omar](https://github.com/taylan/openpeon-omar)
- License: CC-BY-NC-4.0