### PR TITLE
Fix minecraft_villager pack preview_sounds

### DIFF
--- a/index.json
+++ b/index.json
@@ -1611,11 +1611,11 @@
       "tags": [
         "gaming",
         "minecraft",
-        "villager"
+        "mojang"
       ],
       "preview_sounds": [
-        "sounds/villager_idle1.ogg",
-        "sounds/villager_accept1.ogg"
+        "villager_idle1.ogg",
+        "villager_accept1.ogg"
       ],
       "added": "2026-02-24",
       "updated": "2026-02-24"


### PR DESCRIPTION
# Fix minecraft_villager pack preview_sounds

- Fix preview_sounds not working on https://www.peonping.com/ pick your packs section
- Change one tag to the company that made Minecraft