### PR TITLE
Add jarvis pack — J.A.R.V.I.S. British formal AI assistant

### DIFF
--- a/index.json
+++ b/index.json
@@ -324,9 +324,9 @@
       "display_name": "Arc Raiders Pack",
       "version": "1.0.0",
       "description": "Arc Raiders sound effects",
-      "author": { 
-        "name": "A3mercury", 
-        "github": "A3mercury" 
+      "author": {
+        "name": "A3mercury",
+        "github": "A3mercury"
       },
       "trust_tier": "community",
       "categories": [
@@ -337,7 +337,7 @@
         "input.required",
         "resource.limit",
         "session.end"
-       ],
+      ],
       "language": "en",
       "license": "MCC-BY-NC-4.0T",
       "sound_count": 7,
@@ -346,9 +346,13 @@
       "source_ref": "v1.0.0",
       "source_path": ".",
       "manifest_sha256": "3df840bfb19b6815cfae30c0192c587d411b86e9d9b9fc7a63e0216848ed76ed",
-      "tags": ["gaming", "arc", "goop"],
+      "tags": [
+        "gaming",
+        "arc",
+        "goop"
+      ],
       "preview_sounds": [
-        "TracingVictory.mp3", 
+        "TracingVictory.mp3",
         "Blueprint.mp3"
       ],
       "added": "2026-02-20",
@@ -396,9 +400,9 @@
     },
     {
       "name": "arthas_ru",
-      "display_name": "Артас Рыцарь Смерти (Russian)",
+      "display_name": "\u0410\u0440\u0442\u0430\u0441 \u0420\u044b\u0446\u0430\u0440\u044c \u0421\u043c\u0435\u0440\u0442\u0438 (Russian)",
       "version": "1.0.0",
-      "description": "WC3 Death Knight Arthas — all 20 Russian voice lines mapped to CESP categories",
+      "description": "WC3 Death Knight Arthas \u2014 all 20 Russian voice lines mapped to CESP categories",
       "author": {
         "name": "samokay",
         "github": "samokay"
@@ -1473,6 +1477,48 @@
       "updated": "2026-02-12"
     },
     {
+      "name": "jarvis",
+      "display_name": "J.A.R.V.I.S.",
+      "version": "1.0.0",
+      "description": "Just A Rather Very Intelligent System. Formal British AI assistant voice notifications with Daniel's voice, including Mr. Stark references.",
+      "author": {
+        "name": "Boke7",
+        "github": "Boke7"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en-GB",
+      "license": "MIT",
+      "sound_count": 29,
+      "total_size_bytes": 1789952,
+      "source_repo": "Boke7/peonping-jarvis",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "6410a3a4f75c80bbd093a40d7ca3d56457a8c3e9dca57067427ab6cab27c5622",
+      "tags": [
+        "british",
+        "formal",
+        "ai",
+        "marvel",
+        "tts",
+        "elevenlabs"
+      ],
+      "preview_sounds": [
+        "sounds/task_acknowledge_4.mp3",
+        "sounds/task_complete_4.mp3"
+      ],
+      "added": "2026-02-25",
+      "updated": "2026-02-25"
+    },
+    {
       "name": "league_of_legends",
       "display_name": "League of Legends",
       "version": "1.0.0",
@@ -1588,7 +1634,7 @@
       "version": "1.0.1",
       "description": "Villager sound pack from Minecraft.",
       "author": {
-        "name": "Eric Keränen",
+        "name": "Eric Ker\u00e4nen",
         "github": "Mahamurahti"
       },
       "trust_tier": "community",
@@ -3309,9 +3355,9 @@
     },
     {
       "name": "starrail-kafka-peon-pack",
-      "display_name": "\u5D29\u574F\u661F\u7A79\u94C1\u9053\u002D\u5361\u8299\u5361\u8BED\u97F3\u5305",
+      "display_name": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
       "version": "1.0.1",
-      "description": "\u5D29\u574F\u661F\u7A79\u94C1\u9053\u002D\u5361\u8299\u5361\u8BED\u97F3\u5305",
+      "description": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
       "author": {
         "name": "0w0miki",
         "github": "0w0miki"
@@ -3513,48 +3559,48 @@
       "updated": "2026-02-19"
     },
     {
-  "name": "tf2_sniper",
-  "display_name": "TF2 Sniper",
-  "version": "1.0.0",
-  "description": "TF2 Sniper sound pack from Team Fortress 2",
-  "author": {
-    "name": "Breadcat",
-    "github": "thebreadcat"
-  },
-  "trust_tier": "community",
-  "categories": [
-    "session.start",
-    "session.end",
-    "task.acknowledge",
-    "task.progress",
-    "task.complete",
-    "task.error",
-    "input.required",
-    "resource.limit",
-    "user.spam"
-  ],
-  "language": "en",
-  "license": "CC-BY-NC-4.0",
-  "sound_count": 56,
-  "total_size_bytes": 2920947,
-  "source_repo": "thebreadcat/tf2-sniper-pack",
-  "source_ref": "v1.0.0",
-  "source_path": ".",
-  "manifest_sha256": "b7139a7c340f5dd9eafe08656989fe6539e961fee190c1fac82bf1e4321d9104",
-  "tags": [
-    "gaming",
-    "tf2",
-    "valve",
-    "fps"
-  ],
-  "preview_sounds": [
-    "sniper_battlecry03.mp3",
-    "sniper_cheers05.mp3",
-    "sniper_jaratetoss01.mp3"
-  ],
-  "added": "2026-02-19",
-  "updated": "2026-02-19"
-},
+      "name": "tf2_sniper",
+      "display_name": "TF2 Sniper",
+      "version": "1.0.0",
+      "description": "TF2 Sniper sound pack from Team Fortress 2",
+      "author": {
+        "name": "Breadcat",
+        "github": "thebreadcat"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "session.end",
+        "task.acknowledge",
+        "task.progress",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 56,
+      "total_size_bytes": 2920947,
+      "source_repo": "thebreadcat/tf2-sniper-pack",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "b7139a7c340f5dd9eafe08656989fe6539e961fee190c1fac82bf1e4321d9104",
+      "tags": [
+        "gaming",
+        "tf2",
+        "valve",
+        "fps"
+      ],
+      "preview_sounds": [
+        "sniper_battlecry03.mp3",
+        "sniper_cheers05.mp3",
+        "sniper_jaratetoss01.mp3"
+      ],
+      "added": "2026-02-19",
+      "updated": "2026-02-19"
+    },
     {
       "name": "tf2_spy",
       "display_name": "TF2 Spy",


### PR DESCRIPTION
## New pack: J.A.R.V.I.S.

Formal British AI assistant voice notifications inspired by Iron Man's J.A.R.V.I.S., using ElevenLabs Daniel voice.

**Pack repo:** https://github.com/Boke7/peonping-jarvis

## Details

- 29 sounds across 7 categories
- British English (en-GB)
- Includes character phrases like "Of course, Mr. Stark", "As you wish, Mr. Stark", "Mission accomplished"
- Generated with ElevenLabs TTS (Daniel voice, eleven_multilingual_v2)
- License: MIT

## Categories covered

- `session.start` (4 sounds)
- `task.acknowledge` (7 sounds)
- `task.complete` (6 sounds)
- `task.error` (4 sounds)
- `input.required` (4 sounds)
- `resource.limit` (2 sounds)
- `user.spam` (2 sounds)