### PR TITLE
Add gilfoyle sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -1803,7 +1803,7 @@
       "source_repo": "mpospirit/openpeon-gilfoyle",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "5b02b5e35dcfad52b508cf4ee1e6d8dc595b6859c81de8435fc4a083989791ae",
+      "manifest_sha256": "a892ec40c4dc10d986cd120e09bf11474e7f6a1a5d2f09de7aac4554e730adf1",
       "tags": [
         "tv",
         "silicon-valley",


### PR DESCRIPTION
## New pack: Gilfoyle

Adds the **Gilfoyle** community sound pack to the registry.

- **Source:** [mpospirit/openpeon-gilfoyle](https://github.com/mpospirit/openpeon-gilfoyle)
- **Ref:** v1.0.0
- **Language:** en
- **License:** CC-BY-NC-4.0
- **Sounds:** 40 across all 9 CESP categories (6 core + 3 extended)
- **Size:** ~39 MB

Voice lines from Bertram Gilfoyle (*Silicon Valley*).