### PR TITLE
Update aom-italian to v1.1.0 (WAV format)

### DIFF
--- a/index.json
+++ b/index.json
@@ -491,7 +491,7 @@
     {
       "name": "aom-italian",
       "display_name": "Age of Mythology - Italian",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Italian voice lines from Age of Mythology campaign: Arkantos, Ajax, Amanra, Kastor, Chirone and more",
       "author": {
         "name": "f-liva",
@@ -512,11 +512,11 @@
       "language": "it",
       "license": "CC-BY-NC-4.0",
       "sound_count": 64,
-      "total_size_bytes": 1305582,
+      "total_size_bytes": 7163618,
       "source_repo": "f-liva/openpeon-aom-italian",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.1.0",
       "source_path": ".",
-      "manifest_sha256": "36722f8624fe7195e6f8fd53357ddd8c3146d63aff619cbf2fca9c38d6e4ecb2",
+      "manifest_sha256": "d52d1512912348f98f01c1b7adc43d2d1ff151cdd30931c733fabc0aa45700e9",
       "tags": [
         "gaming",
         "age-of-mythology",
@@ -524,8 +524,8 @@
         "rts"
       ],
       "preview_sounds": [
-        "arkantos-bene-cosi.mp3",
-        "ajax-era-ora.mp3"
+        "arkantos-bene-cosi.wav",
+        "ajax-era-ora.wav"
       ],
       "added": "2026-02-27",
       "updated": "2026-02-27"


### PR DESCRIPTION
## Summary
- Updates **aom-italian** pack from v1.0.0 to v1.1.0
- All 64 sounds converted from MP3 to WAV (PCM 16-bit, 44.1kHz) for compatibility with `paplay`/PulseAudio on WSL
- Updated `manifest_sha256`, `total_size_bytes`, `source_ref`, and `preview_sounds`

## Changes
| Field | Before | After |
|---|---|---|
| version | 1.0.0 | 1.1.0 |
| source_ref | v1.0.0 | v1.1.0 |
| total_size_bytes | 1,305,582 | 7,163,618 |
| format | MP3 | WAV |

## Test plan
- [ ] CI validation passes on index.json
- [ ] Source repo tag v1.1.0 is accessible
- [ ] manifest_sha256 matches openpeon.json at v1.1.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)