### PR TITLE
fix: update the-big-lebowski pack to v1.0.1

### DIFF
--- a/index.json
+++ b/index.json
@@ -5043,11 +5043,11 @@
     {
       "name": "the-big-lebowski",
       "display_name": "The Big Lebowski",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "The Dude abides. Iconic lines from The Big Lebowski.",
       "author": {
         "name": "Taylan Aydinli",
-        "github": "taylanaydinli"
+        "github": "taylan"
       },
       "trust_tier": "community",
       "categories": [
@@ -5066,9 +5066,9 @@
       "sound_count": 160,
       "total_size_bytes": 6095239,
       "source_repo": "taylan/openpeon-the-big-lebowski",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": ".",
-      "manifest_sha256": "d20f53a2b3f1cf1be898f5ed2cf34fdcfd89978b5745e682c4cf2fc0afa94d3a",
+      "manifest_sha256": "ee46fe2e0c838f65737e306d51c1f2e37ba2f3177e543c4540e029f1a0292f2d",
       "tags": [
         "movie",
         "comedy",


### PR DESCRIPTION
## Summary
- Fixes `author.github` in manifest (`taylanaydinli` → `taylan`)
- Bumps version to v1.0.1, updates manifest_sha256

No audio changes — metadata fix only.