### PR TITLE
feat: add 16 Stronghold Crusader lord packs v1.1.0

### DIFF
--- a/index.json
+++ b/index.json
@@ -4708,7 +4708,7 @@
     {
       "name": "stronghold-abbot",
       "display_name": "The Abbot (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Abbot voice lines from Stronghold Crusader — scheming monastery lord",
       "author": {
         "name": "Marko Jevic",
@@ -4731,7 +4731,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-abbot",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "a1edd8950bfac88b4af48153d99e547c62d559e2d90f1500f9177092329d3138",
+      "manifest_sha256": "e508bd071d3588b3366c4f53adcfa536547e642d3300d88b197e5aa68b88065e",
       "tags": [
         "gaming",
         "stronghold",
@@ -4748,7 +4748,7 @@
     {
       "name": "stronghold-caliph",
       "display_name": "The Caliph (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Caliph voice lines from Stronghold Crusader — fierce desert warlord",
       "author": {
         "name": "Marko Jevic",
@@ -4771,7 +4771,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-caliph",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "66a44434883063793689cb4fb0cb077350e3ff46bd548f0ac36aae000aba7bfb",
+      "manifest_sha256": "2485102d79dbd44fe54838417adeec3d412abe72cda3bac8a425c4d54be5015c",
       "tags": [
         "gaming",
         "stronghold",
@@ -4788,7 +4788,7 @@
     {
       "name": "stronghold-emir",
       "display_name": "The Emir (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Emir voice lines from Stronghold Crusader — cautious Arabian ally",
       "author": {
         "name": "Marko Jevic",
@@ -4811,7 +4811,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-emir",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "9f1cda7e93ed2c66cf843a74f0e611fc91a50e1f4602d5e53c78ee4214eb9874",
+      "manifest_sha256": "97f273510f6fa2996d4892b5670bb9ceb8765f48305670c0a937c04742b7b64d",
       "tags": [
         "gaming",
         "stronghold",
@@ -4828,7 +4828,7 @@
     {
       "name": "stronghold-frederick",
       "display_name": "Emperor Frederick (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Emperor Frederick voice lines from Stronghold Crusader — imperial European lord",
       "author": {
         "name": "Marko Jevic",
@@ -4851,7 +4851,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-frederick",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "e4d338048466188e71e9e365f7a68f7043815cc428d73da934493230e50a3c27",
+      "manifest_sha256": "11aa20e629093fc3e9fd0e85060bdc018615aa869c08bfcdbd4ecee75fdde6f6",
       "tags": [
         "gaming",
         "stronghold",
@@ -4868,7 +4868,7 @@
     {
       "name": "stronghold-marshal",
       "display_name": "The Marshal (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Marshal voice lines from Stronghold Crusader — gruff military commander",
       "author": {
         "name": "Marko Jevic",
@@ -4891,7 +4891,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-marshal",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "bae00c488e968d178e9a3bf3fcbd16024a3b38901e4eb46109f6387692afe0d1",
+      "manifest_sha256": "289cb74a33869bdfff83ffa41d7dcc81c45bc991ce8cc941d8e8bf150b598b8b",
       "tags": [
         "gaming",
         "stronghold",
@@ -4908,7 +4908,7 @@
     {
       "name": "stronghold-nizar",
       "display_name": "Nizar (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Nizar voice lines from Stronghold Crusader — mysterious assassin lord",
       "author": {
         "name": "Marko Jevic",
@@ -4931,7 +4931,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-nizar",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "9afc56969581fe2594d0d97ca174f191c29448c8f3e87ad431abc4d8c28e395e",
+      "manifest_sha256": "8f2f2b9bbc03f4417bfa1636df7a1820e7dd338143e8684ebda93913562813c1",
       "tags": [
         "gaming",
         "stronghold",
@@ -4948,7 +4948,7 @@
     {
       "name": "stronghold-philip",
       "display_name": "King Philip (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "King Philip voice lines from Stronghold Crusader — vain French king",
       "author": {
         "name": "Marko Jevic",
@@ -4971,7 +4971,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-philip",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "fc5b132916fbc5281c0691f29fd10be37dd528f2efe409e59d9592b90562f886",
+      "manifest_sha256": "0e6f44c4d8d5a7739374318ceef044c02ff3eeb7d71bebfb2ce98c61aa966707",
       "tags": [
         "gaming",
         "stronghold",
@@ -4988,7 +4988,7 @@
     {
       "name": "stronghold-pig",
       "display_name": "The Pig (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Pig voice lines from Stronghold Crusader — brutal villain lord",
       "author": {
         "name": "Marko Jevic",
@@ -5011,7 +5011,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-pig",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "93b46e16a3d80d5bc69a23fc61d8d89e8807f9856c4212a7fc7fb3c604586bf7",
+      "manifest_sha256": "e232aca1ac6098fa5b32ba55948640a422f8e5b1676560aa8ad4f063c05dbd31",
       "tags": [
         "gaming",
         "stronghold",
@@ -5028,7 +5028,7 @@
     {
       "name": "stronghold-rat",
       "display_name": "The Rat (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Rat voice lines from Stronghold Crusader — scheming cowardly villain",
       "author": {
         "name": "Marko Jevic",
@@ -5051,7 +5051,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-rat",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "dbf0b6650707af881fe1c852fe2e89ce23c4630035c6fb2086f7f6ef15b61952",
+      "manifest_sha256": "81ebfb8f4aa0e3be2c1f709c6ded198eddd54062ec43b4fc1dd3dbea03720e4e",
       "tags": [
         "gaming",
         "stronghold",
@@ -5068,7 +5068,7 @@
     {
       "name": "stronghold-richard",
       "display_name": "Richard the Lionheart (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Richard the Lionheart voice lines from Stronghold Crusader — noble crusader king",
       "author": {
         "name": "Marko Jevic",
@@ -5091,7 +5091,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-richard",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "eb6841797c1f05eaaba4e8b38d7306de416f6b41da84f3e9ba9e9ff474073710",
+      "manifest_sha256": "a65b997b7207ffc7325e20f42c4bbb4090423ee402cfc3d117b1737a1dba9a14",
       "tags": [
         "gaming",
         "stronghold",
@@ -5108,7 +5108,7 @@
     {
       "name": "stronghold-saladin",
       "display_name": "Saladin (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Saladin voice lines from Stronghold Crusader — honourable opposing sultan",
       "author": {
         "name": "Marko Jevic",
@@ -5131,7 +5131,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-saladin",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "886a2d121f83cddd6165f2774166fde260d8f5fe988f8ee7c890655d5548b453",
+      "manifest_sha256": "81e8a8a7068f3328fee3dcb384545144c9a64618bdfca2bd468e3098f23b3c41",
       "tags": [
         "gaming",
         "stronghold",
@@ -5148,7 +5148,7 @@
     {
       "name": "stronghold-sheriff",
       "display_name": "The Sheriff (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Sheriff voice lines from Stronghold Crusader — greedy villain lord",
       "author": {
         "name": "Marko Jevic",
@@ -5171,7 +5171,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-sheriff",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "3eed9c2db8ee4dced7471c237b15ff45d03457e1b5f5b9ddff263a286f093fa2",
+      "manifest_sha256": "7bf9ebf1eb7cf42efa0a258e08659783248ec3eec4beb05bb8eb57c8dfdcc643",
       "tags": [
         "gaming",
         "stronghold",
@@ -5188,7 +5188,7 @@
     {
       "name": "stronghold-snake",
       "display_name": "The Snake (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Snake voice lines from Stronghold Crusader — sly manipulative villain",
       "author": {
         "name": "Marko Jevic",
@@ -5211,7 +5211,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-snake",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "835241e341582962a711e6b43f38c62a7ef888f1d05c38383f33de9c92105258",
+      "manifest_sha256": "181fc51d31c140d5c0fbaa01e841f0b37b36f17937ff17093c325f55e3fe1098",
       "tags": [
         "gaming",
         "stronghold",
@@ -5228,7 +5228,7 @@
     {
       "name": "stronghold-sultan",
       "display_name": "The Sultan (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Sultan voice lines from Stronghold Crusader — poetic Arabian ally",
       "author": {
         "name": "Marko Jevic",
@@ -5251,7 +5251,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-sultan",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "3d1d674ff86c786b7438dfe4f78ba25d576ac553ae423389bc9537580ec29612",
+      "manifest_sha256": "cc6c0c17ea47ffc772caf2f1c2f57f81d384e6f7afda84c4d1892d93dd8913cd",
       "tags": [
         "gaming",
         "stronghold",
@@ -5268,7 +5268,7 @@
     {
       "name": "stronghold-wazir",
       "display_name": "The Wazir (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Wazir voice lines from Stronghold Crusader — aggressive desert ally",
       "author": {
         "name": "Marko Jevic",
@@ -5291,7 +5291,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-wazir",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "afca00bc76509e5bfa3a22438462bb6c382ff188e9a4c2424feedcf4fcd556db",
+      "manifest_sha256": "0a570b59120ade5e8212b5da35659693d5c7078226db0243dbed52c88f96a6ce",
       "tags": [
         "gaming",
         "stronghold",
@@ -5308,7 +5308,7 @@
     {
       "name": "stronghold-wolf",
       "display_name": "The Wolf (Stronghold Crusader)",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "The Wolf voice lines from Stronghold Crusader — ruthless villain lord",
       "author": {
         "name": "Marko Jevic",
@@ -5331,7 +5331,7 @@
       "source_repo": "openpeon-stronghold/openpeon-stronghold-wolf",
       "source_ref": "v1.0.0",
       "source_path": ".",
-      "manifest_sha256": "bdd7d88c4dbdb2d646de21fff3b9fb228a5a6abcc2a61bee9b2e48a72bb3c722",
+      "manifest_sha256": "78ad857b195c6fa9916669f901f018bd3bbbe78aad81fd8eba1749a9347deca9",
       "tags": [
         "gaming",
         "stronghold",


### PR DESCRIPTION
## Summary

- Adds 16 Stronghold Crusader lord voice packs (Abbot, Caliph, Emir, Frederick, Marshal, Nizar, Philip, Pig, Rat, Richard, Saladin, Sheriff, Snake, Sultan, Wazir, Wolf)
- All packs at v1.1.0 — includes per-sound SHA256 checksums and LICENSE file in each pack repo
- All manifest SHA256s computed from the final manifests

## Test plan

- [ ] Verify each pack entry is alphabetically ordered in `index.json`
- [ ] Spot-check manifest SHA256s against pack repos
- [ ] Confirm all 7 CESP categories are covered per pack where sounds exist