### PR TITLE
Update Stronghold Crusader packs to v1.2.0 with short names

### DIFF
--- a/index.json
+++ b/index.json
@@ -1,6399 +1,6399 @@
 {
-  "version": 1,
-  "packs": [
-    {
-      "name": "acolyte_de",
-      "display_name": "Undead Acolyte (DE)",
-      "version": "1.0.0",
-      "description": "German Undead Acolyte sound pack from Warcraft III",
-      "author": {
-        "name": "Kaffeetasse",
-        "github": "Kaffeetasse"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "de",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 31,
-      "total_size_bytes": 2506838,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.1.0",
-      "source_path": "acolyte_de",
-      "manifest_sha256": "74d4953f5053c3d2f9423b7bd1af224a596d5d66d842951cd0d67ea0d31d2f34",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "AcolyteReady1.wav",
-        "AcolyteBuildingComplete1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "acolyte_es",
-      "display_name": "Acólito Muertos Vivientes Warcraft III (ES)",
-      "version": "1.0.2",
-      "description": "Spanish Undead Acolyte sound pack from Warcraft III",
-      "author": {
-        "name": "lurecas",
-        "github": "lurecas"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "es",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 29,
-      "total_size_bytes": 2197202,
-      "source_repo": "lurecas/openpeon-w3-acolyte-es",
-      "source_ref": "v1.0.2",
-      "source_path": "acolyte_es",
-      "manifest_sha256": "8a08bb9bdfadbb3a24601c51b4338c3fe0a5beba07c7ad59ba6354b60815cb18",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "AcolyteReady1.wav",
-        "AcolyteWhat1.wav"
-      ],
-      "added": "2026-02-16",
-      "updated": "2026-02-16"
-    },
-    {
-      "name": "acolyte_ru",
-      "display_name": "Undead Acolyte (Russian)",
-      "version": "1.0.0",
-      "description": "Undead Acolyte (Russian) sound pack from Warcraft III",
-      "author": {
-        "name": "maksimfedin",
-        "github": "maksimfedin"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "ru",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 30,
-      "total_size_bytes": 2984156,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "acolyte_ru",
-      "manifest_sha256": "c988eff118c207b8bd8f6902c0686e6f9e65a4901c215c8ae51b894546357a23",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "AcolyteReady1.wav",
-        "AcolyteBuildingComplete1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "ae_qianyu",
-      "display_name": "明日方舟:终末地 陈千语",
-      "version": "1.0.4",
-      "description": "明日方舟:终末地 陈千语 语音包",
-      "author": {
-        "name": "LiRiu",
-        "github": "LiRiu"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "zh-CN",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 9,
-      "total_size_bytes": 364120,
-      "source_repo": "LiRiu/qianyu-chen-pack",
-      "source_ref": "v1.0.4",
-      "source_path": ".",
-      "manifest_sha256": "50fd5866b2f025deba93723ceae9aa77ef88302efa7915711d881222c391d67b",
-      "tags": [
-        "gaming",
-        "明日方舟:终末地",
-        "arknights:endfield"
-      ],
-      "preview_sounds": [
-        "new-1.mp3",
-        "dang-1.mp3",
-        "dang-2.mp3",
-        "dang-3.mp3"
-      ],
-      "added": "2026-02-15",
-      "updated": "2026-02-15"
-    },
-    {
-      "name": "afewgoodmen",
-      "display_name": "A Few Good Men",
-      "version": "1.0.1",
-      "description": "A Few Good Men quotes for your Claude Code notifications. 19 clips across 7 categories.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 19,
-      "total_size_bytes": 779377,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.1.1",
-      "source_path": "afewgoodmen",
-      "manifest_sha256": "e198f8aab308fe1f49324c880603a571ac2597a903a4092aba309fce56dd8efb",
-      "tags": [
-        "movie-quotes",
-        "drama",
-        "courtroom",
-        "jack-nicholson",
-        "tom-cruise"
-      ],
-      "preview_sounds": [
-        "kaffee_hi.mp3",
-        "kaffee_im_sorry.mp3"
-      ],
-      "added": "2026-02-26",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "airplane",
-      "display_name": "Airplane!",
-      "version": "1.0.1",
-      "description": "Airplane! quotes for your Claude Code notifications. 17 clips across 7 categories.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 17,
-      "total_size_bytes": 474374,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.1.1",
-      "source_path": "airplane",
-      "manifest_sha256": "b66478f685cd600c4f793b457d3dd96fc14cc2f11e6bf7e17fae21a506ecf043",
-      "tags": [
-        "movie-quotes",
-        "comedy",
-        "parody",
-        "leslie-nielsen",
-        "disaster-movie"
-      ],
-      "preview_sounds": [
-        "dont_call_me_shirley.mp3",
-        "johnny_jive.mp3"
-      ],
-      "added": "2026-02-26",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "anchorman_brick",
-      "display_name": "Brick Tamland",
-      "version": "1.0.0",
-      "description": "Non-sequiturs as a service.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 14,
-      "total_size_bytes": 309862,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "anchorman_brick",
-      "manifest_sha256": "169b4a1d476ceef5c020bb0ad044e43c52de3750d3d14d9f4bedf69430e794ab",
-      "tags": [
-        "movie-quotes",
-        "anchorman",
-        "comedy",
-        "steve-carell",
-        "brick-tamland",
-        "will-ferrell"
-      ],
-      "preview_sounds": [
-        "dont_know_what_yelling_about.mp3",
-        "fiberglass_insulation.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "anchorman_burgundy",
-      "display_name": "Ron Burgundy",
-      "version": "1.0.0",
-      "description": "San Diego's finest anchor, kind of a big deal.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 446242,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "anchorman_burgundy",
-      "manifest_sha256": "40c5ab35c2639b1897ba76bd0a92d1763c18f974cef9f8b837c23f20864f47ce",
-      "tags": [
-        "movie-quotes",
-        "anchorman",
-        "comedy",
-        "will-ferrell",
-        "ron-burgundy",
-        "san-diego"
-      ],
-      "preview_sounds": [
-        "by_the_beard_of_zeus.mp3",
-        "dont_act_like_youre_not_impressed.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "anchorman_news_team",
-      "display_name": "News Team",
-      "version": "1.0.0",
-      "description": "Channel 4 News Team Ensemble.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 10,
-      "total_size_bytes": 387527,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "anchorman_news_team",
-      "manifest_sha256": "3654c1c3ac5a2a6a86e4c15dd5dbe437155a055ccc302d5c721406340b41ea5d",
-      "tags": [
-        "movie-quotes",
-        "anchorman",
-        "comedy",
-        "will-ferrell",
-        "news-team",
-        "sex-panther"
-      ],
-      "preview_sounds": [
-        "dorothy_mantooth.mp3",
-        "its_called_sex_panther.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "aoe2",
-      "display_name": "Age of Empires II Taunts",
-      "version": "1.0.0",
-      "description": "Age of Empires II Taunts sound pack from Age of Empires II",
-      "author": {
-        "name": "halilb",
-        "github": "halilb"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 42,
-      "total_size_bytes": 630371,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "aoe2",
-      "manifest_sha256": "a1f0d0fb71166075a641c9f350d7f876e225c1b62627f5abc722b29d201b5dcd",
-      "tags": [
-        "gaming",
-        "age-of-empires",
-        "rts"
-      ],
-      "preview_sounds": [
-        "1-yes.mp3",
-        "1-yes.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "aoe4_fr_imperial",
-      "display_name": "Age of Empires IV - French Villager Voices",
-      "version": "1.0.2",
-      "description": "French villager voice lines from Age of Empires IV, extracted from the game files.",
-      "author": {
-        "name": "Guillaume et Louison",
-        "github": "ghusse"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.end",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "task.progress"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 410,
-      "total_size_bytes": 16269304,
-      "source_repo": "ghusse/openpeon_sounds",
-      "source_ref": "v1.0.2",
-      "source_path": "aoe4-french-imperial",
-      "manifest_sha256": "137e9f5491725f961d0385a5bd985c1c2a72e0f8c986e817ca03131d4f82c535",
-      "tags": [
-        "gaming",
-        "age-of-empires",
-        "rts"
-      ],
-      "preview_sounds": [
-        "sounds/French_villagerfemale_select_ihigh_chigh_01_alt01_mp3.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "aom-greeks",
-      "display_name": "Age of Mythology - Greeks",
-      "version": "1.0.0",
-      "description": "Ancient Greek dialogue lines from Age of Mythology villagers, soldiers, and heroes",
-      "author": {
-        "name": "Konstantinos Diamantidis",
-        "github": "kdmnt"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "task.progress",
-        "user.spam",
-        "session.end"
-      ],
-      "language": "el",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 35,
-      "total_size_bytes": 380216,
-      "source_repo": "kdmnt/aom-greeks",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "c9dc36a7ce808a0215de8272edf6bd06acbcc3ab894b073d93d1e44a51ff9cfb",
-      "tags": [
-        "gaming",
-        "age-of-mythology",
-        "ancient-greek",
-        "greek"
-      ],
-      "preview_sounds": [
-        "villager-male-move-vulome.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "aom-italian",
-      "display_name": "Age of Mythology - Italian",
-      "version": "1.1.0",
-      "description": "Italian voice lines from Age of Mythology campaign: Arkantos, Ajax, Amanra, Kastor, Chirone and more",
-      "author": {
-        "name": "f-liva",
-        "github": "f-liva"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "task.progress",
-        "user.spam",
-        "session.end"
-      ],
-      "language": "it",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 64,
-      "total_size_bytes": 7163618,
-      "source_repo": "f-liva/openpeon-aom-italian",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "d52d1512912348f98f01c1b7adc43d2d1ff151cdd30931c733fabc0aa45700e9",
-      "tags": [
-        "gaming",
-        "age-of-mythology",
-        "italian",
-        "rts"
-      ],
-      "preview_sounds": [
-        "arkantos-bene-cosi.wav",
-        "ajax-era-ora.wav"
-      ],
-      "added": "2026-02-27",
-      "updated": "2026-02-27"
-    },
-    {
-      "name": "aom_greek",
-      "display_name": "Age of Mythology - Greek Villager",
-      "version": "1.0.0",
-      "description": "Age of Mythology - Greek Villager sound pack from Age of Mythology",
-      "author": {
-        "name": "amitaifrey",
-        "github": "amitaifrey"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 20,
-      "total_size_bytes": 1211988,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "aom_greek",
-      "manifest_sha256": "c5a85333382a1008426048b063144f8e4e92cfbcaf58d99d6a4f6ced33645c46",
-      "tags": [
-        "gaming",
-        "age-of-mythology",
-        "rts"
-      ],
-      "preview_sounds": [
-        "Greeks_Villager_Male_Select_4_AoM.wav",
-        "Greeks_Villager_Male_Build_AoM.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "arc_raiders",
-      "display_name": "Arc Raiders Pack",
-      "version": "1.0.0",
-      "description": "Arc Raiders sound effects",
-      "author": {
-        "name": "A3mercury",
-        "github": "A3mercury"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "session.end"
-      ],
-      "language": "en",
-      "license": "MCC-BY-NC-4.0T",
-      "sound_count": 7,
-      "total_size_bytes": 1100000,
-      "source_repo": "A3mercury/openpeon-arcraiders",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "3df840bfb19b6815cfae30c0192c587d411b86e9d9b9fc7a63e0216848ed76ed",
-      "tags": [
-        "gaming",
-        "arc",
-        "goop"
-      ],
-      "preview_sounds": [
-        "TracingVictory.mp3",
-        "Blueprint.mp3"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "arnold",
-      "display_name": "Arnold Schwarzenegger",
-      "version": "1.0.0",
-      "description": "Iconic Arnold Schwarzenegger movie one-liners. Your terminal is now the Governator.",
-      "author": {
-        "name": "mmichael0413",
-        "github": "mmichael0413"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 15,
-      "total_size_bytes": 1131042,
-      "source_repo": "mmichael0413/openpeon-arnold",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "e2d59741a3c5b3dba64e923b90652dbcbf793f92a7d1452bfe4216fcfda618c6",
-      "tags": [
-        "movies",
-        "action",
-        "arnold",
-        "terminator"
-      ],
-      "preview_sounds": [
-        "ill-be-back.mp3",
-        "hasta-la-vista-baby.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "arthas_ru",
-      "display_name": "Артас Рыцарь Смерти (Russian)",
-      "version": "1.0.0",
-      "description": "WC3 Death Knight Arthas — all 20 Russian voice lines mapped to CESP categories",
-      "author": {
-        "name": "samokay",
-        "github": "samokay"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "ru",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 20,
-      "total_size_bytes": 8633344,
-      "source_repo": "samokay/arthas_ru",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "391eec37a929112db5106a59809d4282f9c1071de110a09783baba7626ed3d85",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "russian",
-        "arthas",
-        "death-knight"
-      ],
-      "preview_sounds": [
-        "frostmourne_hungers.wav",
-        "for_the_lich_king.wav"
-      ],
-      "added": "2026-02-22",
-      "updated": "2026-02-22"
-    },
-    {
-      "name": "blues_brothers",
-      "display_name": "Blues Brothers",
-      "version": "1.0.0",
-      "description": "The full Blues Brothers experience.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 9,
-      "total_size_bytes": 568709,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "blues_brothers",
-      "manifest_sha256": "933cbfc67a9267825ba7e94e3db922bbeaac5b9887b1bc35a4ab8dfce4de2772",
-      "tags": [
-        "movie-quotes",
-        "the-blues-brothers",
-        "comedy",
-        "john-belushi",
-        "dan-aykroyd",
-        "blues",
-        "music"
-      ],
-      "preview_sounds": [
-        "106_test.mp3",
-        "band_is_back_together.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "blues_brothers_elwood",
-      "display_name": "Elwood Blues",
-      "version": "1.0.0",
-      "description": "Deadpan delivery, all business.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 11,
-      "total_size_bytes": 421572,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "blues_brothers_elwood",
-      "manifest_sha256": "102e9e841d843103ad998051b025bb74d3819e75db46588f2c98b0ae640a7c77",
-      "tags": [
-        "movie-quotes",
-        "the-blues-brothers",
-        "comedy",
-        "dan-aykroyd",
-        "elwood-blues",
-        "blues"
-      ],
-      "preview_sounds": [
-        "106_miles_to_chicago.mp3",
-        "cop_motor.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "blues_brothers_jake",
-      "display_name": "Jake Blues",
-      "version": "1.0.0",
-      "description": "Scheming, devout (sort of), on a mission from God.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 17,
-      "total_size_bytes": 731153,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "blues_brothers_jake",
-      "manifest_sha256": "df8fd54a41f647b338f60d6d274072b45f2f46b56ca7cc4e38ef49a8578164f1",
-      "tags": [
-        "movie-quotes",
-        "the-blues-brothers",
-        "comedy",
-        "john-belushi",
-        "jake-blues",
-        "blues"
-      ],
-      "preview_sounds": [
-        "are_you_the_police.mp3",
-        "band_is_back_together.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "brewmaster_ru",
-      "display_name": "Pandaren Brewmaster (Russian)",
-      "version": "1.0.0",
-      "description": "Pandaren Brewmaster (Russian) sound pack from Warcraft III",
-      "author": {
-        "name": "rubywwwilde",
-        "github": "rubywwwilde"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "ru",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 23,
-      "total_size_bytes": 2551528,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "brewmaster_ru",
-      "manifest_sha256": "f4e23ae91110b0beb9e241661c8a4bb659cf867f7e8ff1cf5f71528f96583c11",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "AnyoneWantBeer.mp3",
-        "OneMore.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "cc_commando",
-      "display_name": "C&C: Commando",
-      "version": "1.0.1",
-      "description": "Command & Conquer Commando sound pack",
-      "author": {
-        "name": "shaneboulden",
-        "github": "shaneboulden"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 13,
-      "total_size_bytes": 169035,
-      "source_repo": "shaneboulden/openpeon-cc-commando",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "2e103bb35cdcd1d03b2c73e92b797b6dd7521effe2033ff1caa084a89b9fbd6d",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts",
-        "commando"
-      ],
-      "preview_sounds": [
-        "present-for-ya.mp3",
-        "left-handed.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "ccg_china_dozer",
-      "display_name": "C&C Generals: China Dozer",
-      "version": "1.0.1",
-      "description": "China dozer sound pack from Command & Conquer: Generals",
-      "author": {
-        "name": "YonahKarp",
-        "github": "YonahKarp"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 26,
-      "total_size_bytes": 1307964,
-      "source_repo": "YonahKarp/openpeon-ccg-china-dozer",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "a3bcaad00511b5036c0eccc12eef72c0bfa0318a1ff1dff4de98261547d1591c",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "A_very_good_plan_general.mp3",
-        "Construction_built_to_spec.mp3"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "ccg_gla_worker",
-      "display_name": "C&C Generals: GLA Worker",
-      "version": "1.0.1",
-      "description": "GLA worker sound pack from Command & Conquer: Generals",
-      "author": {
-        "name": "YonahKarp",
-        "github": "YonahKarp"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 37,
-      "total_size_bytes": 1613593,
-      "source_repo": "YonahKarp/openpeon-ccg-gla-worker",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "7e65595f1a858f52be4246f4c2c0fe22ee824de052bddb9d0b3766ed73798c2a",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "I_guess_I_should_help_out.mp3",
-        "All_work_is_complete.mp3"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "ccg_us_dozer",
-      "display_name": "C&C Generals: USA Dozer",
-      "version": "1.0.0",
-      "description": "USA dozer sound pack from Command & Conquer: Generals",
-      "author": {
-        "name": "YonahKarp",
-        "github": "YonahKarp"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 32,
-      "total_size_bytes": 1421229,
-      "source_repo": "YonahKarp/openpeon-ccg-us-dozer",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "da99a15d9fa3bafe9ebd97ba5f64257a1ba51a62c295c5604c118b21f29311fd",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "Lets_get_to_work.mp3",
-        "That_ones_done.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "charlie_sheen",
-      "display_name": "Charlie Sheen",
-      "version": "1.0.0",
-      "description": "Charlie Sheen's iconic interview quotes — Winning, tiger blood, and more.",
-      "author": {
-        "name": "rootbarb",
-        "github": "rootbarb"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 19,
-      "total_size_bytes": 16293980,
-      "source_repo": "rootbarb/openpeon-charlie-sheen",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "5e87469f61fd92ed8717d79b4f1fee3133bf78640c4addd44811da257db4dd92",
-      "tags": [
-        "celebrity",
-        "meme",
-        "interview"
-      ],
-      "preview_sounds": [
-        "Winning.wav"
-      ],
-      "added": "2026-02-16",
-      "updated": "2026-02-16"
-    },
-    {
-      "name": "clean_chimes",
-      "display_name": "Clean Chimes",
-      "version": "1.0.0",
-      "description": "Professional notification tones and chimes for a workspace-friendly experience",
-      "author": {
-        "name": "chris-halim",
-        "github": "chris-halim"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "Mixkit License",
-      "sound_count": 7,
-      "total_size_bytes": 2984006,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "main",
-      "source_path": "clean_chimes",
-      "manifest_sha256": "6c8caa737d8daf579899dd1f89da5ad513e85c55e7cea5cfa563acea6f8cb994",
-      "tags": [
-        "professional",
-        "minimal",
-        "notifications"
-      ],
-      "preview_sounds": [
-        "CC_Start.wav",
-        "CC_Complete.wav"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "cortana",
-      "display_name": "Cortana",
-      "version": "1.0.3",
-      "description": "Cortana from Halo",
-      "author": {
-        "name": "A3mercury",
-        "github": "A3mercury"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 11,
-      "total_size_bytes": 699000,
-      "source_repo": "A3mercury/openpeon-cortana",
-      "source_ref": "v1.0.3",
-      "source_path": ".",
-      "manifest_sha256": "f34e11d8e904411e4d7c6e84d49744b98557156d7cd6b66cc8e987d2f427da22",
-      "tags": [
-        "gaming",
-        "halo",
-        "cortana"
-      ],
-      "preview_sounds": [
-        "MissMe.mp3",
-        "Answer.mp3",
-        "AlreadyBegun.mp3",
-        "Scanning.mp3",
-        "Ride.mp3",
-        "LocatedPillar.mp3",
-        "ThreatLevel1.mp3",
-        "SleepWell.mp3",
-        "TakeTooLong.mp3",
-        "WhatAreYouDoing.mp3"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "counterstrike",
-      "display_name": "Counter-Strike",
-      "version": "1.0.2",
-      "description": "Classic Counter-Strike radio commands",
-      "author": {
-        "name": "colbyfayock",
-        "github": "colbyfayock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 15,
-      "total_size_bytes": 983040,
-      "source_repo": "colbyfayock/openpeon-counterstrike",
-      "source_ref": "v1.0.2",
-      "source_path": ".",
-      "manifest_sha256": "87189d450468f7f69bf25d0292a8f6c18366063e52f4875da7adf283ff428015",
-      "tags": [
-        "gaming",
-        "counterstrike",
-        "cs"
-      ],
-      "preview_sounds": [
-        "lock-and-load.wav",
-        "roger.wav"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "d2_deckard_cain",
-      "display_name": "Deckard Cain (Diablo 2)",
-      "version": "1.0.0",
-      "description": "Stay a while and listen! Deckard Cain voice lines from Diablo 2.",
-      "author": {
-        "name": "rootbarb",
-        "github": "rootbarb"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 14,
-      "total_size_bytes": 999232,
-      "source_repo": "rootbarb/openpeon-d2-deckard-cain",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "12971dd87e673276fa11bbb0fa1b695bcdfef4288cc85b6e137039099bf46158",
-      "tags": [
-        "gaming",
-        "diablo",
-        "blizzard",
-        "rpg"
-      ],
-      "preview_sounds": [
-        "StayAWhileAndListen.wav"
-      ],
-      "added": "2026-02-16",
-      "updated": "2026-02-16"
-    },
-    {
-      "name": "deadlock_dynamo",
-      "display_name": "Dynamo (Deadlock)",
-      "version": "1.0.0",
-      "description": "Dynamo voice pack from Valve's Deadlock",
-      "author": {
-        "name": "mwaterman29",
-        "github": "mwaterman29"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 48,
-      "total_size_bytes": 1038668,
-      "source_repo": "mwaterman29/openpeon-deadlock-dynamo",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "c1c983029329cf6e419086be004e3d4f4ccff2a7feefabfaf2eb49dac704d2de",
-      "tags": [
-        "gaming",
-        "deadlock",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "dynamo_select_06.mp3",
-        "dynamo_ping_good_job_01.mp3"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "deadpool",
-      "display_name": "Deadpool (2016)",
-      "version": "1.0.0",
-      "description": "Maximum effort! Audio clips from Deadpool (2016) featuring Ryan Reynolds' iconic one-liners.",
-      "author": {
-        "name": "victor",
-        "github": "xtrimsystems"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 35,
-      "total_size_bytes": 1267975,
-      "source_repo": "xtrimsystems/peon-ping-deadpool",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "cc44c05be18d5e8e050b19826d1ed1a805d7fb835da65b1e0183254f0b192759",
-      "tags": [
-        "movie",
-        "deadpool",
-        "marvel",
-        "comedy",
-        "ryan-reynolds"
-      ],
-      "preview_sounds": [
-        "sounds/Maximum_effort.mp3",
-        "sounds/I_m_touching_myself_tonight.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "diehard",
-      "display_name": "Die Hard",
-      "version": "1.0.1",
-      "description": "Die Hard quotes for your Claude Code notifications. 16 clips across 7 categories.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 832002,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.1.1",
-      "source_path": "diehard",
-      "manifest_sha256": "c397104fbb3c340922d34466414f8f1a6a42c40fbc7733a5abab7f1d1a7c075d",
-      "tags": [
-        "movie-quotes",
-        "action",
-        "christmas",
-        "bruce-willis",
-        "hans-gruber",
-        "alan-rickman"
-      ],
-      "preview_sounds": [
-        "powell_welcome_to_the_party.mp3",
-        "welcome_to_the_party.mp3"
-      ],
-      "added": "2026-02-26",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "dobby",
-      "display_name": "Dobby the House-Elf",
-      "version": "1.0.0",
-      "description": "Dobby is here to help! A house-elf themed sound pack for OpenCode featuring Dobby from Harry Potter.",
-      "author": {
-        "name": "johmara",
-        "github": "johmara"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.error",
-        "input.required"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 6,
-      "total_size_bytes": 2523948,
-      "source_repo": "johmara/openpeon-dobby",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "1e96f9b91fec1b71ce0516900b12d9ec8e27c029f46a7589888fcdefc3e0399b",
-      "tags": [
-        "movie",
-        "harry-potter",
-        "house-elf",
-        "fantasy"
-      ],
-      "preview_sounds": [
-        "sounds/dobby-hello.wav",
-        "sounds/dobby-done.wav"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "dota2_axe",
-      "display_name": "Axe (Dota 2)",
-      "version": "1.0.0",
-      "description": "Axe (Dota 2) sound pack from Dota 2",
-      "author": {
-        "name": "x-n2o",
-        "github": "x-n2o"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 20,
-      "total_size_bytes": 538432,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.3.0",
-      "source_path": "dota2_axe",
-      "manifest_sha256": "5c1dd1cdc3c1517ca7c554b9bab4b5ca22f99ba3cc625ec7e4c527bd266b28a8",
-      "tags": [
-        "gaming",
-        "dota2",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "AxeIsReady.mp3",
-        "AxeHappened.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "dota2_ember_spirit",
-      "display_name": "Ember Spirit (Dota 2)",
-      "version": "1.0.0",
-      "description": "Ember Spirit (Dota 2) sound pack — 'Balance in all things.'",
-      "author": {
-        "name": "kmelkon",
-        "github": "kmelkon"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 26,
-      "total_size_bytes": 931168,
-      "source_repo": "kmelkon/openpeon-dota2",
-      "source_ref": "main",
-      "source_path": "dota2_ember_spirit",
-      "manifest_sha256": "14b9a86e260574aa3600569a015de55c04956c096c5139aeec8999c2f8a42fab",
-      "tags": [
-        "gaming",
-        "dota2",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "EmberSpirit.mp3",
-        "BalanceInAllThings.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "dota2_invoker",
-      "display_name": "Invoker (Dota 2)",
-      "version": "1.0.0",
-      "description": "Invoker (Dota 2) sound pack — 'So begins a new age of knowledge.'",
-      "author": {
-        "name": "bwarren2",
-        "github": "bwarren2"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 24,
-      "total_size_bytes": 828573,
-      "source_repo": "bwarren2/peonpack-invoker",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "b1e8ea61f82d07332981d31e51b28dce4eb90beb5d369371149d99fe84210c3d",
-      "tags": [
-        "gaming",
-        "dota2",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "Invoker.mp3",
-        "GloriousInvocation.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "dota2_phantom_lancer",
-      "display_name": "Phantom Lancer (Dota 2)",
-      "version": "1.0.0",
-      "description": "Phantom Lancer (Dota 2) sound pack — 'From one: an army.'",
-      "author": {
-        "name": "kmelkon",
-        "github": "kmelkon"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 28,
-      "total_size_bytes": 829847,
-      "source_repo": "kmelkon/openpeon-dota2",
-      "source_ref": "v1.0.0",
-      "source_path": "dota2_phantom_lancer",
-      "manifest_sha256": "d4db1490a124269e9b48198ab8625a44bfb8b803f9d25c6926bfc459ddb015d4",
-      "tags": [
-        "gaming",
-        "dota2",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "PhantomLancer.mp3",
-        "FromOneAnArmy.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "dota2_witch_doctor",
-      "display_name": "Witch Doctor (Dota 2)",
-      "version": "1.0.0",
-      "description": "Witch Doctor (Dota 2) sound pack — 'De Doctor is in!'",
-      "author": {
-        "name": "kmelkon",
-        "github": "kmelkon"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 26,
-      "total_size_bytes": 899825,
-      "source_repo": "kmelkon/openpeon-dota2",
-      "source_ref": "main",
-      "source_path": "dota2_witch_doctor",
-      "manifest_sha256": "941b8a21b0eb4cd6003b803199cf273bf7fc33395b0ea60855efa046fbe8bf04",
-      "tags": [
-        "gaming",
-        "dota2",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "DeDoctorisIn.mp3",
-        "LookAtItGo.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "dota2_zeus",
-      "display_name": "Zeus (Dota 2)",
-      "version": "1.0.0",
-      "description": "Zeus (Dota 2) sound pack — 'Your god has arrived.'",
-      "author": {
-        "name": "kmelkon",
-        "github": "kmelkon"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 34,
-      "total_size_bytes": 1219940,
-      "source_repo": "kmelkon/openpeon-dota2",
-      "source_ref": "main",
-      "source_path": "dota2_zeus",
-      "manifest_sha256": "333c7a4f7294842a9c849d0e84ecbe640d15e9674ae104ae040a7e3f3d1e8cc2",
-      "tags": [
-        "gaming",
-        "dota2",
-        "valve",
-        "moba"
-      ],
-      "preview_sounds": [
-        "Zeus.mp3",
-        "Thunderstruck.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "duke_nukem",
-      "display_name": "Duke Nukem",
-      "version": "1.0.0",
-      "description": "Duke Nukem sound pack from Duke Nukem",
-      "author": {
-        "name": "unknown",
-        "github": "unknown"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 24,
-      "total_size_bytes": 7737086,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "duke_nukem",
-      "manifest_sha256": "d31b4bc666904b66280606a16476a1db80d01a5077107611bd3ab81be21b1214",
-      "tags": [
-        "gaming",
-        "duke-nukem",
-        "fps",
-        "retro"
-      ],
-      "preview_sounds": [
-        "KickAssChewGum.wav",
-        "KaboomBaby.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "dva",
-      "display_name": "D.Va Overwatch",
-      "version": "1.0.0",
-      "description": "D.Va voice lines from Overwatch - includes Korean and English lines.",
-      "author": {
-        "name": "Leo",
-        "github": "leo-rutter"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.acknowledge",
-        "task.error",
-        "input.required"
-      ],
-      "language": "en",
-      "license": "MIT",
-      "sound_count": 17,
-      "total_size_bytes": 285750,
-      "source_repo": "leo-rutter/d.va-pack",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "94fe7bf6e6825d2a4dea378b49c00efff136d029b8a9b6d81b8e7afcbf4d256a",
-      "tags": [
-        "gaming",
-        "Blizzard",
-        "Overwatch"
-      ],
-      "preview_sounds": [
-        "dva-online.mp3",
-        "winky-face.mp3",
-        "gg.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "eve-walle",
-      "display_name": "EVE (Wall-E)",
-      "version": "1.0.1",
-      "description": "Sound pack featuring EVE, the sleek probe robot from Pixar's Wall-E",
-      "author": {
-        "name": "stphnlngdn",
-        "github": "stphnlngdncoding"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 21,
-      "total_size_bytes": 2579136,
-      "source_repo": "stphnlngdncoding/eve-walle",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "c0ae34010e3a34b658ba5f6f90f790d5ebd9ed2852e1ef1d1c5a375161e2eeda",
-      "tags": [
-        "pixar",
-        "wall-e",
-        "robot",
-        "movie"
-      ],
-      "preview_sounds": [
-        "start1.wav",
-        "done1.wav"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "futurama_bender",
-      "display_name": "Bender (Futurama)",
-      "version": "1.0.0",
-      "description": "Bender Bending Rodriguez quotes from Futurama",
-      "author": {
-        "name": "ravenrs",
-        "github": "ravenrs"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 18,
-      "total_size_bytes": 778093,
-      "source_repo": "ravenrs/peon-ping-futurama-bender-",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "8a58349e2fa183a9cd8fa900ee5d7255cfd66f5e31f852441e4e420e3a97fa7b",
-      "tags": [
-        "futurama",
-        "bender",
-        "cartoon",
-        "robot",
-        "comedy"
-      ],
-      "preview_sounds": [
-        "time-for-this-robot-to-get-back-to-work.mp3",
-        "ah-crap.mp3"
-      ],
-      "added": "2026-02-16",
-      "updated": "2026-02-16"
-    },
-    {
-      "name": "gilfoyle",
-      "display_name": "Gilfoyle",
-      "version": "1.0.0",
-      "description": "Bertram Gilfoyle from Silicon Valley",
-      "author": {
-        "name": "mpospirit",
-        "github": "mpospirit"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam",
-        "session.end",
-        "task.progress"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 40,
-      "total_size_bytes": 38999632,
-      "source_repo": "mpospirit/openpeon-gilfoyle",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "a892ec40c4dc10d986cd120e09bf11474e7f6a1a5d2f09de7aac4554e730adf1",
-      "tags": [
-        "tv",
-        "silicon-valley",
-        "comedy"
-      ],
-      "added": "2026-02-27",
-      "updated": "2026-02-27"
-    },
-    {
-      "name": "glados",
-      "display_name": "GLaDOS (Portal)",
-      "version": "1.0.0",
-      "description": "GLaDOS (Portal) sound pack from Portal",
-      "author": {
-        "name": "DoubleGremlin181",
-        "github": "DoubleGremlin181"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 23,
-      "total_size_bytes": 1143346,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "glados",
-      "manifest_sha256": "1e6066a66018f56092b917ae36123f84278b1fb29979642cee664760a1549d8b",
-      "tags": [
-        "gaming",
-        "portal",
-        "valve",
-        "puzzle"
-      ],
-      "preview_sounds": [
-        "Hello.mp3",
-        "GoodNews.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "hal_2001",
-      "display_name": "HAL 9000 (2001: A Space Odyssey)",
-      "version": "1.0.0",
-      "description": "I'm sorry, Dave. I'm afraid I can't do that. Audio clips from HAL 9000 in 2001: A Space Odyssey.",
-      "author": {
-        "name": "jq",
-        "github": "jquintus"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 17,
-      "total_size_bytes": 721994,
-      "source_repo": "jquintus/openpeon-hal-2001",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "984aa115db965f6a8eedfad06757bf69060a501dc8b5a28092ddc3431ddbf228",
-      "tags": [
-        "sci-fi",
-        "movie",
-        "kubrick",
-        "hal9000",
-        "space"
-      ],
-      "preview_sounds": [
-        "open_the_pod_bay_doors_hal_sorry_dave.wav",
-        "good_evening.wav"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "hd2_helldiver",
-      "display_name": "Helldiver (Helldivers 2)",
-      "version": "1.0.0",
-      "description": "Helldiver (Helldivers 2) sound pack from Helldivers 2",
-      "author": {
-        "name": "ZachTaylor99",
-        "github": "ZachTaylor99"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 31,
-      "total_size_bytes": 616665,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "hd2_helldiver",
-      "manifest_sha256": "5b09c3c2ae878c99117b72a6fe444706a8e719caf95326a1878b229cbda6aa60",
-      "tags": [
-        "gaming",
-        "helldivers",
-        "shooter"
-      ],
-      "preview_sounds": [
-        "ReportingForDuty1.mp3",
-        "FoundSomething.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "jarvis",
-      "display_name": "J.A.R.V.I.S.",
-      "version": "1.0.0",
-      "description": "Just A Rather Very Intelligent System. Formal British AI assistant voice notifications with Daniel's voice, including Mr. Stark references.",
-      "author": {
-        "name": "Boke7",
-        "github": "Boke7"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en-GB",
-      "license": "MIT",
-      "sound_count": 29,
-      "total_size_bytes": 1789952,
-      "source_repo": "Boke7/peonping-jarvis",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "6410a3a4f75c80bbd093a40d7ca3d56457a8c3e9dca57067427ab6cab27c5622",
-      "tags": [
-        "british",
-        "formal",
-        "ai",
-        "marvel",
-        "tts",
-        "elevenlabs"
-      ],
-      "preview_sounds": [
-        "sounds/task_acknowledge_4.mp3",
-        "sounds/task_complete_4.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "kaamelott",
-      "display_name": "Kaamelott",
-      "version": "1.0.0",
-      "description": "Best of Kaamelott",
-      "author": {
-        "name": "rsylvian",
-        "github": "rsylvian"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-ND",
-      "sound_count": 16,
-      "total_size_bytes": 991511,
-      "source_repo": "rsylvian/openpeon-kaamelott",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "6d66d07ea4fc77f950c4b6bc63109728acaaed8adc8ea228d0945ed39e9f2fd9",
-      "tags": [
-        "kaamelott",
-        "french",
-        "comedy",
-        "tv-show"
-      ],
-      "preview_sounds": [
-        "trompette.mp3"
-      ],
-      "added": "2026-02-27",
-      "updated": "2026-02-27"
-    },
-    {
-      "name": "league_of_legends",
-      "display_name": "League of Legends",
-      "version": "1.0.0",
-      "description": "Iconic LoL announcer and ping sounds from Summoner's Rift",
-      "author": {
-        "name": "chris-halim",
-        "github": "chris-halim"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 11,
-      "total_size_bytes": 4566618,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "main",
-      "source_path": "league_of_legends",
-      "manifest_sha256": "8c43c51fe82215cf0bc51d8229b3e10b4884783042810e26ae3af2b2e16bffe9",
-      "tags": [
-        "gaming",
-        "league-of-legends",
-        "riot"
-      ],
-      "preview_sounds": [
-        "LOL_WelcomeToSR.wav",
-        "LOL_PentaKill.wav"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "lebowski_big_lebowski",
-      "display_name": "The Big Lebowski",
-      "version": "1.0.0",
-      "description": "Wealthy bluster and achievement-worship.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 13,
-      "total_size_bytes": 546568,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "lebowski_big_lebowski",
-      "manifest_sha256": "146622212b947c987d730c43495dac8ec1a058e6b518be4f88231252938c2110",
-      "tags": [
-        "movie-quotes",
-        "the-big-lebowski",
-        "comedy",
-        "coen-brothers",
-        "david-huddleston",
-        "big-lebowski"
-      ],
-      "preview_sounds": [
-        "achievers.mp3",
-        "are_you_employed_sir.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "lebowski_jesus",
-      "display_name": "Jesus Quintana",
-      "version": "1.0.0",
-      "description": "Nobody fucks with the Jesus. Maximum intimidation, minimum vocabulary.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 12,
-      "total_size_bytes": 294790,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "lebowski_jesus",
-      "manifest_sha256": "8575a783ecc51dced598f00666aa348223caa5dc04582820b2eab4378f9e5862",
-      "tags": [
-        "movie-quotes",
-        "the-big-lebowski",
-        "comedy",
-        "coen-brothers",
-        "john-turturro",
-        "jesus-quintana",
-        "bowling"
-      ],
-      "preview_sounds": [
-        "date_wednesday_baby.mp3",
-        "gonna_fuck_you_up.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "lebowski_maude",
-      "display_name": "Maude Lebowski",
-      "version": "1.0.0",
-      "description": "Intellectual condescension as a notification sound.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 10,
-      "total_size_bytes": 269108,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "lebowski_maude",
-      "manifest_sha256": "efea16ae441a213b1566d38291c94d588d0b393d122afcbdb14adbba949be45a",
-      "tags": [
-        "movie-quotes",
-        "the-big-lebowski",
-        "comedy",
-        "coen-brothers",
-        "julianne-moore",
-        "maude-lebowski"
-      ],
-      "preview_sounds": [
-        "dont_be_fatuous.mp3",
-        "good_man_and_thorough.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "lebowski_the_dude",
-      "display_name": "The Dude",
-      "version": "1.0.0",
-      "description": "The Dude abides... as your coding notification.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 21,
-      "total_size_bytes": 863177,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "lebowski_the_dude",
-      "manifest_sha256": "6b01199a41a160864fd59732819d56787a64ef616d84dbafe6af9e4fd92f010e",
-      "tags": [
-        "movie-quotes",
-        "the-big-lebowski",
-        "comedy",
-        "coen-brothers",
-        "jeff-bridges",
-        "the-dude",
-        "bowling"
-      ],
-      "preview_sounds": [
-        "aggression_will_not_stand.mp3",
-        "far_out_man.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "lebowski_walter",
-      "display_name": "Walter Sobchak",
-      "version": "1.0.0",
-      "description": "Unhinged Vietnam veteran energy for your coding errors.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 19,
-      "total_size_bytes": 713341,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "lebowski_walter",
-      "manifest_sha256": "81550d777d2ef679d79aff5728e0234e756efc549ce108e62f3f5a82d7379c50",
-      "tags": [
-        "movie-quotes",
-        "the-big-lebowski",
-        "comedy",
-        "coen-brothers",
-        "john-goodman",
-        "walter-sobchak",
-        "bowling"
-      ],
-      "preview_sounds": [
-        "calmer_than_you_are.mp3",
-        "dont_roll_on_shabbos.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "marcel",
-      "display_name": "Marcel",
-      "version": "1.0.0",
-      "description": "Legendary quotes of Marcel Merčiak.",
-      "author": {
-        "name": "Marián Čamák",
-        "github": "mcamak"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "sk",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 17,
-      "total_size_bytes": 332952,
-      "source_repo": "mcamak/openpeon-marcel",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "0f4128148ebbd46fa24a670fbb94c8f6e7c6c2ebf94b552a0b466ab83194f583",
-      "tags": [
-        "stress"
-      ],
-      "preview_sounds": [
-        "06_osemkrat-sa-nieco-pytam.mp3",
-        "16_preco-ste-ma-tak-zarezali-do-pici.mp3"
-      ],
-      "added": "2026-02-18",
-      "updated": "2026-02-18"
-    },
-    {
-      "name": "milujipraci",
-      "display_name": "Miluji Práci",
-      "version": "1.0.0",
-      "description": "Legendary quotes of Luboš fixing Lakatoš.",
-      "author": {
-        "name": "František Záhora",
-        "github": "arguit"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.error",
-        "input.required"
-      ],
-      "language": "cs",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 30,
-      "total_size_bytes": 1917736,
-      "source_repo": "arguit/openpeon-milujipraci",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "4619e4ce72dc6d307e12f18c1ee22f3156c9790e57e1ea1ef33889a7176ba943",
-      "tags": [
-        "stress"
-      ],
-      "preview_sounds": [
-        "past-vedle-pasti-pico.mp3",
-        "ne-nenasadis-ho.mp3"
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "minecraft_villager",
-      "display_name": "Minecraft Villager",
-      "version": "1.0.1",
-      "description": "Villager sound pack from Minecraft.",
-      "author": {
-        "name": "Eric Keränen",
-        "github": "Mahamurahti"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 19,
-      "total_size_bytes": 118573,
-      "source_repo": "Mahamurahti/openpeon-minecraft-villager",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "16f5fc57cf0928dc2a3943c80fc41561ed5ad252b5b79a3537fa6dd9d6339217",
-      "tags": [
-        "gaming",
-        "minecraft",
-        "mojang"
-      ],
-      "preview_sounds": [
-        "villager_idle1.ogg",
-        "villager_accept1.ogg"
-      ],
-      "added": "2026-02-24",
-      "updated": "2026-02-24"
-    },
-    {
-      "name": "molag_bal",
-      "display_name": "Molag Bal",
-      "version": "1.0.0",
-      "description": "Molag Bal sound pack from The Elder Scrolls",
-      "author": {
-        "name": "lloydaf",
-        "github": "lloydaf"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 29,
-      "total_size_bytes": 25545048,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "molag_bal",
-      "manifest_sha256": "401792f309e0831b5995ff178a41785a3952682a769bca21fed34c018c743fca",
-      "tags": [
-        "gaming",
-        "elder-scrolls",
-        "bethesda",
-        "rpg"
-      ],
-      "preview_sounds": [
-        "greeting_1.wav",
-        "complete_1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "mr_meeseeks",
-      "display_name": "Mr. Meeseeks (Rick and Morty)",
-      "version": "1.0.0",
-      "description": "Look at me! Mr. Meeseeks voice lines from Rick and Morty. Can do!",
-      "author": {
-        "name": "kasperhendriks",
-        "github": "kasperhendriks"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.error",
-        "input.required"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 30,
-      "total_size_bytes": 1246342,
-      "source_repo": "kasperhendriks/openpeon-mrmeeseeks",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "94f038d50b963eefec3892a5dafef7930d5b23ec229fbefa1bd790e80965ca34",
-      "tags": [
-        "tv",
-        "animation",
-        "comedy",
-        "rick-and-morty"
-      ],
-      "preview_sounds": [
-        "sounds/im_mr_meeseeks_look_at_me.mp3",
-        "sounds/can_do.mp3",
-        "sounds/all_done.mp3"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "mullemeck",
-      "display_name": "Mulle Meck (SV)",
-      "version": "1.0.0",
-      "description": "Mulle meck is eager to build!",
-      "author": {
-        "name": "zyk",
-        "github": "zyk"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "session.end"
-      ],
-      "language": "sv",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 18,
-      "total_size_bytes": 330387,
-      "source_repo": "zyk/openpeon-mullemeck",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "80c6e90dd90033f41df6515006894c2d0d844dcd3d6c7ce857ade13993d8e1fd",
-      "tags": [
-        "gaming"
-      ],
-      "preview_sounds": [
-        "molijoxer_och_mojanger.mp3"
-      ],
-      "added": "2026-02-28",
-      "updated": "2026-02-28"
-    },
-    {
-      "name": "murloc",
-      "display_name": "Murloc",
-      "version": "1.0.0",
-      "description": "Murloc sound pack from Warcraft III",
-      "author": {
-        "name": "Ferror",
-        "github": "Ferror"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 7,
-      "total_size_bytes": 70354,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.1.0",
-      "source_path": "murloc",
-      "manifest_sha256": "e9b5c431d0fcc907d7992634c6636188d533fd7e90370018c803d89528680153",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard"
-      ],
-      "preview_sounds": [
-        "mrrgll.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "ocarina_of_time",
-      "display_name": "Ocarina of Time",
-      "version": "1.0.0",
-      "description": "Navi and friends from The Legend of Zelda: Ocarina of Time",
-      "author": {
-        "name": "kmostdiek-k",
-        "github": "kmostdiek-k"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 13,
-      "total_size_bytes": 755172,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.1.0",
-      "source_path": "ocarina_of_time",
-      "manifest_sha256": "56094abe0d6e975c7a05c48dd64ca2cb5dd33e543fa93611a3030f7835bffecb",
-      "tags": [
-        "gaming",
-        "zelda",
-        "nintendo"
-      ],
-      "preview_sounds": [
-        "OOT_Navi_Hello1.wav",
-        "OOT_Secret.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "office_space",
-      "display_name": "Office Space",
-      "version": "1.0.0",
-      "description": "Office Space ensemble - Milton, the Bobs, and more.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 12,
-      "total_size_bytes": 367520,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "office_space",
-      "manifest_sha256": "1856ba4c1099eedc40b29e2de5470c38b0de3c2b582eb3c94524d942d0bfd529",
-      "tags": [
-        "movie-quotes",
-        "office-space",
-        "comedy",
-        "mike-judge",
-        "milton",
-        "tps-reports",
-        "work"
-      ],
-      "preview_sounds": [
-        "believe_you_have_my_stapler.mp3",
-        "bob_slydell.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "office_space_lumbergh",
-      "display_name": "Bill Lumbergh",
-      "version": "1.0.0",
-      "description": "Yeah, that would be great.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 17,
-      "total_size_bytes": 713560,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "office_space_lumbergh",
-      "manifest_sha256": "67a264ec9d874bb969d9a165a59549493cf59f2d8414b5f62f26bf6832bc09ee",
-      "tags": [
-        "movie-quotes",
-        "office-space",
-        "comedy",
-        "mike-judge",
-        "gary-cole",
-        "bill-lumbergh",
-        "work",
-        "tps-reports"
-      ],
-      "preview_sounds": [
-        "come_in_on_saturday.mp3",
-        "come_in_on_sunday.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "office_space_peter",
-      "display_name": "Peter Gibbons",
-      "version": "1.0.0",
-      "description": "Corporate soul-death as notification sounds.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 768664,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "office_space_peter",
-      "manifest_sha256": "a68900afb212cca02038a4d67245e22b384dc8e836555d0bd9f685a08fcdc3bb",
-      "tags": [
-        "movie-quotes",
-        "office-space",
-        "comedy",
-        "mike-judge",
-        "ron-livingston",
-        "peter-gibbons",
-        "work"
-      ],
-      "preview_sounds": [
-        "case_of_the_mondays.mp3",
-        "dont_care_if_laid_off.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "omar",
-      "display_name": "Omar Little (The Wire)",
-      "version": "1.1.1",
-      "description": "Omar comin'. Iconic Omar Little lines from The Wire.",
-      "author": {
-        "name": "Taylan Aydinli",
-        "github": "taylan"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.end",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "task.progress",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 32,
-      "total_size_bytes": 1075304,
-      "source_repo": "taylan/openpeon-omar",
-      "source_ref": "v1.1.1",
-      "source_path": ".",
-      "manifest_sha256": "74aab994a66bfa2ddca57acbc40e562dad8b9162319b765e7dbb49cbbc07e860",
-      "tags": [
-        "tv",
-        "the-wire",
-        "hbo"
-      ],
-      "preview_sounds": [
-        "come-at-the-king.mp3",
-        "indeed.mp3"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "peasant",
-      "display_name": "Human Peasant",
-      "version": "1.0.0",
-      "description": "Human Peasant sound pack from Warcraft III",
-      "author": {
-        "name": "thomasKn",
-        "github": "thomasKn"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 25,
-      "total_size_bytes": 1310954,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peasant",
-      "manifest_sha256": "7b32349f0c2734edc739c022d8fe3185b7be8f59e15f70743564c597c3a11848",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.wav",
-        "PeasantReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peasant_cz",
-      "display_name": "Lidský rolník (CZ)",
-      "version": "1.0.0",
-      "description": "Lidský rolník (CZ) sound pack from Warcraft III",
-      "author": {
-        "name": "vojtabiberle",
-        "github": "vojtabiberle"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "cs",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 25,
-      "total_size_bytes": 1804107,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peasant_cz",
-      "manifest_sha256": "337d61b71f94d0d1fd35cd57ed3af6c9cb0597031f003259fd1b52df24b24245",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.wav",
-        "PeasantReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peasant_es",
-      "display_name": "Campesino Humano (ES)",
-      "version": "1.0.0",
-      "description": "Campesino Humano (ES) sound pack from Warcraft III",
-      "author": {
-        "name": "Keralin",
-        "github": "Keralin"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "es",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 25,
-      "total_size_bytes": 1342974,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peasant_es",
-      "manifest_sha256": "065d7800530edee7867d73cb0fd479df0ab8df2e187bf1e3f8a5366476b73dc7",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.wav",
-        "PeasantReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peasant_fr",
-      "display_name": "Paysan Humain (FR)",
-      "version": "1.0.0",
-      "description": "Paysan Humain (FR) sound pack from Warcraft III",
-      "author": {
-        "name": "thomasKn",
-        "github": "thomasKn"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 25,
-      "total_size_bytes": 1580126,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peasant_fr",
-      "manifest_sha256": "2662c8df5d454b554e1541b4a441d58f1620e9665a8a15388a07720e89ed31f6",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.wav",
-        "PeasantReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peasant_ru",
-      "display_name": "Human Peasant (Russian)",
-      "version": "1.0.0",
-      "description": "Human Peasant (Russian) sound pack from Warcraft III",
-      "author": {
-        "name": "maksimfedin",
-        "github": "maksimfedin"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "ru",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 18,
-      "total_size_bytes": 979198,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peasant_ru",
-      "manifest_sha256": "565dda4d4d90339f30e44a29b3456c3ca8e6228633cb64dba33b764ea6181db2",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.wav",
-        "PeasantWhat3.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon",
-      "display_name": "Orc Peon",
-      "version": "1.0.0",
-      "description": "Orc Peon sound pack from Warcraft III",
-      "author": {
-        "name": "tonyyont",
-        "github": "tonyyont"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 27,
-      "total_size_bytes": 872012,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peon",
-      "manifest_sha256": "565178cd55b46a66d443a9e8c001fa51926413d5e562677b43a5de2381c7fe8e",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonReady1.wav",
-        "PeonReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon_cz",
-      "display_name": "Orčí peón (CZ)",
-      "version": "1.0.0",
-      "description": "Orčí peón (CZ) sound pack from Warcraft III",
-      "author": {
-        "name": "vojtabiberle",
-        "github": "vojtabiberle"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "cs",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 27,
-      "total_size_bytes": 1295067,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peon_cz",
-      "manifest_sha256": "426491ade6b692805fde7425f80a5513b1c15ff54a65288765481328b859c186",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonReady1.wav",
-        "PeonReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon_de",
-      "display_name": "Orc Peon (DE)",
-      "version": "1.0.0",
-      "description": "German Orc Peon sound pack from Warcraft III",
-      "author": {
-        "name": "Kaffeetasse",
-        "github": "Kaffeetasse"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "de",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 27,
-      "total_size_bytes": 1013804,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.1.0",
-      "source_path": "peon_de",
-      "manifest_sha256": "2fd9c89497333efc0c1ddac317d23b0b715d7d29e9744f4105ee189b04253e57",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonReady1.wav",
-        "PeonYes3.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon_es",
-      "display_name": "Peon Orco (ES)",
-      "version": "1.0.0",
-      "description": "Peon Orco (ES) sound pack from Warcraft III",
-      "author": {
-        "name": "Keralin",
-        "github": "Keralin"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "es",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 27,
-      "total_size_bytes": 859036,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peon_es",
-      "manifest_sha256": "082b63a99d86a253dfc6e86061ea6723095a15bd525be0f7bebce803cc23b2f9",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonReady1.wav",
-        "PeonReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon_fr",
-      "display_name": "Peon Orc (FR)",
-      "version": "1.0.0",
-      "description": "Peon Orc (FR) sound pack from Warcraft III",
-      "author": {
-        "name": "thomasKn",
-        "github": "thomasKn"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 27,
-      "total_size_bytes": 971410,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peon_fr",
-      "manifest_sha256": "5c82c4b15252b96b123d6f8cf62efc98f62975196d2af14019a1b2a96c484c9b",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonReady1.wav",
-        "PeonReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon_pl",
-      "display_name": "Orc Peon (Polish)",
-      "version": "1.0.0",
-      "description": "Orc Peon (Polish) sound pack from Warcraft III",
-      "author": {
-        "name": "ArturSkowronski",
-        "github": "ArturSkowronski"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "pl",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 22,
-      "total_size_bytes": 4026800,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "peon_pl",
-      "manifest_sha256": "bdacb2d514f6e85609eebdcb77ad25ecc76a385d1f8929d16843c03c98480b12",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonWhat1.wav",
-        "PeonYes1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "peon_ru",
-      "display_name": "Orc Peon (Russian)",
-      "version": "1.0.0",
-      "description": "Orc Peon (Russian) sound pack from Warcraft III",
-      "author": {
-        "name": "maksimfedin",
-        "github": "maksimfedin"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "ru",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 25,
-      "total_size_bytes": 1117894,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.3.0",
-      "source_path": "peon_ru",
-      "manifest_sha256": "05b0076d2f5601f6bc9b6a493440b5e7b98d200b979e77a955e7f22d5b7aa886",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonReady1.wav",
-        "PeonReady1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "postal2_pl",
-      "display_name": "Postal 2 (Polish)",
-      "version": "1.0.1",
-      "description": "Sounds from Postal 2 (Polish), mostly Dude.",
-      "author": {
-        "name": "deoomen",
-        "github": "deoomen"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "session.end",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "pl",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 25,
-      "total_size_bytes": 3977010,
-      "source_repo": "deoomen/openpeon-postal2_pl",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "e93d9bc3e100ce7e3bb5adc5a35d20fcee33e375b1cf76ab7556858bd0e79825",
-      "tags": [
-        "gaming",
-        "hardcore",
-        "mature",
-        "funny",
-        "postal"
-      ],
-      "preview_sounds": [
-        "sounds/Dude_RegretNothing2.wav",
-        "sounds/dude_sure.wav"
-      ],
-      "added": "2026-02-28",
-      "updated": "2026-02-28"
-    },
-    {
-      "name": "professor-layton",
-      "display_name": "Professor Layton",
-      "version": "1.0.0",
-      "description": "Every puzzle has an answer! SFX from Professor Layton and the Curious Village by Level-5.",
-      "author": {
-        "name": "Skyforce77",
-        "github": "skyforce77"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 6,
-      "total_size_bytes": 297416,
-      "source_repo": "skyforce77/openpeon-professor-layton",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "738a6a554ccbe514d5aed07d9d1e1dc02ea68f938c4694edd93a9f2604d46529",
-      "tags": [
-        "puzzle",
-        "gentleman",
-        "nintendo",
-        "level5",
-        "game",
-        "mystery"
-      ],
-      "preview_sounds": [
-        "sounds/puzzle_solved.mp3",
-        "sounds/hint_coin.mp3"
-      ],
-      "added": "2026-02-26",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "protoss",
-      "display_name": "Protoss (StarCraft)",
-      "version": "1.0.0",
-      "description": "StarCraft Protoss voice lines and sound effects — en taro Adun!",
-      "author": {
-        "name": "Cody Born",
-        "github": "codyborn"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 10,
-      "total_size_bytes": 316849,
-      "source_repo": "codyborn/protoss-sounds",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "2b94f5dbf942bc87bb47b8215965cc8e87b555f649f232ccc4ab1ced682f13a9",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "protoss",
-        "sci-fi"
-      ],
-      "preview_sounds": [
-        "sounds/protoss_carrier.mp3",
-        "sounds/protoss_pylons.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "ra2_eva_commander",
-      "display_name": "RA2 EVA Commander",
-      "version": "1.0.1",
-      "description": "Red Alert 2 Allied EVA commander voice lines mixed with Tanya responses.",
-      "author": {
-        "name": "zenvor",
-        "github": "zenvor"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam",
-        "session.end"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 23,
-      "total_size_bytes": 1369358,
-      "source_repo": "zenvor/openpeon-ra2-eva-commander",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "e219c745cb3e5704d39e075b24dee48b4a87f4e49947ee8bb4b6b9b6435f8bf2",
-      "tags": [
-        "gaming",
-        "red-alert",
-        "cnc",
-        "rts",
-        "eva"
-      ],
-      "preview_sounds": [
-        "battle-control-online.wav",
-        "yeah-baby.wav"
-      ],
-      "added": "2026-03-02",
-      "updated": "2026-03-02"
-    },
-    {
-      "name": "ra2_kirov",
-      "display_name": "RA2 Kirov Airship",
-      "version": "1.0.0",
-      "description": "RA2 Kirov Airship sound pack from Command & Conquer: Red Alert 2",
-      "author": {
-        "name": "i-zhirov",
-        "github": "i-zhirov"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 19,
-      "total_size_bytes": 367012,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "ra2_kirov",
-      "manifest_sha256": "2099a50bd9fa0db593981f80ac4141bffa4cd2626bd3d501fe32c82d7e472094",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "KirovReporting.mp3",
-        "BombardiersToYourStations.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "ra2_peon",
-      "display_name": "Red Alert 2 Voice Lines",
-      "version": "1.0.0",
-      "description": "Classic Red Alert 2 unit voice lines for coding feedback. From conscripts to Kirov airships, let Soviet and Allied forces narrate your coding session.",
-      "author": {
-        "name": "Emiel Verkade",
-        "github": "emielver"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.progress",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam",
-        "session.end"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 438,
-      "total_size_bytes": 3113236,
-      "source_repo": "emielver/ra2_peon",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "1f355a5809ebc4e7af77a891b04c4b47997f22f35242b3153fc74b244c5a7355",
-      "tags": [
-        "red-alert",
-        "rts",
-        "command-conquer",
-        "soviet",
-        "allied",
-        "military",
-        "gaming"
-      ],
-      "preview_sounds": [
-        "a-new-comrade-joins-us.mp3",
-        "acknowledged.mp3",
-        "cha-ching.mp3",
-        "comrade.mp3",
-        "conscript-reporting.mp3",
-        "kirov-reporting_1.mp3",
-        "kirov-reporting.mp3",
-        "orders-comrade.mp3",
-        "ready-comrade.mp3",
-        "yes-comrade.mp3"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "ra2_soviet_engineer",
-      "display_name": "RA2 Soviet Engineer",
-      "version": "1.0.0",
-      "description": "RA2 Soviet Engineer sound pack from Command & Conquer: Red Alert 2",
-      "author": {
-        "name": "msukkari",
-        "github": "msukkari"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 12,
-      "total_size_bytes": 58190,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "ra2_soviet_engineer",
-      "manifest_sha256": "bc588337d5dd0edfb86f0b9a727b45f2be826558dc99a4dcb3f2b2dd0718f28c",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ToolsReady.mp3",
-        "Engineering.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "ra2_yuri",
-      "display_name": "RA2 Yuri (Yuri's Revenge)",
-      "version": "1.0.0",
-      "description": "Yuri Prime & Yuri Clone sound pack from Command & Conquer: Red Alert 2 - Yuri's Revenge",
-      "author": {
-        "name": "testy-cool",
-        "github": "testy-cool"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 55,
-      "total_size_bytes": 3353696,
-      "source_repo": "testy-cool/openpeon-ra2-yuri",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "73afb91726904c3582b7013b1984938a27d77845fcd4090d71ba1705c7c2fc6b",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "iyupsea.wav",
-        "iyupcrd.wav"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "ra_soviet",
-      "display_name": "Red Alert Soviet Soldier",
-      "version": "1.0.0",
-      "description": "Red Alert Soviet Soldier sound pack from Command & Conquer: Red Alert",
-      "author": {
-        "name": "JairusKhan",
-        "github": "JairusKhan"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 36,
-      "total_size_bytes": 1239943,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "ra_soviet",
-      "manifest_sha256": "b61eac06505c37426c2e1a7e51ef64d1b15c0013b18bde5c9fa003990ce7bbf2",
-      "tags": [
-        "gaming",
-        "command-and-conquer",
-        "ea",
-        "rts"
-      ],
-      "preview_sounds": [
-        "SovietAwaitingOrders.wav",
-        "SovietReadyAndWaiting.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "rick",
-      "display_name": "Rick Sanchez",
-      "version": "1.0.0",
-      "description": "Rick Sanchez sound pack from Rick and Morty",
-      "author": {
-        "name": "ranjitp16",
-        "github": "ranjitp16"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 14,
-      "total_size_bytes": 420414,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "rick",
-      "manifest_sha256": "c0097725338aa6d9f308d1948dbb60600105f5c10f8329c091e5f974758e42e1",
-      "tags": [
-        "tv",
-        "animation",
-        "comedy"
-      ],
-      "preview_sounds": [
-        "Rick_Sanchez_Jerry_.mp3",
-        "Rick_Sanchez_Fun.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "sc2_carrier",
-      "display_name": "Carrier (StarCraft II)",
-      "version": "1.0.0",
-      "description": "Protoss Carrier unit voice lines from StarCraft II",
-      "author": {
-        "name": "Bryce Evans",
-        "github": "bryce-evans"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required"
-      ],
-      "language": "en",
-      "license": "Fair Use",
-      "sound_count": 7,
-      "total_size_bytes": 214331,
-      "source_repo": "bryce-evans/openpeon-sc2-carrier",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "6a55be29c99b933e022586fd929f48519db7d3bd4ac7c54f8e461d6eafc9dd2e",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "protoss",
-        "blizzard"
-      ],
-      "preview_sounds": [
-        "carrier-has-arrived.mp3",
-        "we-are-ready.ogg"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "sc2_stalker",
-      "display_name": "Stalker (StarCraft II)",
-      "version": "1.1.0",
-      "description": "Protoss Stalker voice lines from StarCraft II",
-      "author": {
-        "name": "Sergej Lopatkin",
-        "github": "selop"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam",
-        "session.end"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 26,
-      "total_size_bytes": 1504193,
-      "source_repo": "selop/peon-pack-stalker-sc2",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "df48a1307e9568e2f1c6cfe4e0a1f8e70f79946285d1faca10f654a262824500",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "protoss",
-        "blizzard"
-      ],
-      "preview_sounds": [
-        "you-require-my-skills.mp3",
-        "i-serve-for-now.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-15"
-    },
-    {
-      "name": "sc_battlecruiser",
-      "display_name": "StarCraft Battlecruiser",
-      "version": "1.0.0",
-      "description": "StarCraft Battlecruiser sound pack from StarCraft",
-      "author": {
-        "name": "garysheng",
-        "github": "garysheng"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 13,
-      "total_size_bytes": 423109,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "sc_battlecruiser",
-      "manifest_sha256": "70ea29abbb0b380def6cebda44af2d06e7191e6ee90565e4119cf0a4df472b50",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "BattlecruiserOperational.mp3",
-        "HailingFrequenciesOpen.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "sc_dropship",
-      "display_name": "StarCraft Dropship",
-      "version": "1.0.0",
-      "description": "StarCraft 1 Terran Dropship voice lines",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 16,
-      "total_size_bytes": 555313,
-      "source_repo": "kschmidtjr1/openpeon-sc_dropship",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "91fc44d0ebc43b0d80d9a467a040ef8144e7485b99c57ef8a989d14947fce035",
-      "tags": [
-        "gaming",
-        "starcraft"
-      ],
-      "preview_sounds": [
-        "CanITakeYourOrder.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "sc_firebat",
-      "display_name": "StarCraft Firebat",
-      "version": "2.0.0",
-      "description": "StarCraft Firebat sound pack — 17 SC1 voice lines across all 7 CESP categories, featuring 'Need a light?' and propane references",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 17,
-      "total_size_bytes": 544489,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.3.0",
-      "source_path": "sc_firebat",
-      "manifest_sha256": "1820390815ee8f591608b2fda4c6990de121b6f35bacb856ed6bdf17b6dd14e0",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "NeedALight.mp3",
-        "FireItUp.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "sc_ghost",
-      "display_name": "StarCraft Ghost",
-      "version": "1.0.0",
-      "description": "StarCraft 1 Terran Ghost unit voice lines",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 15,
-      "total_size_bytes": 505532,
-      "source_repo": "kschmidtjr1/openpeon-sc_ghost",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "5a9aefc59e38a37984f4ac1368679711bd5d7b6ed1615ce3617a67fd6227cd4e",
-      "tags": [
-        "gaming",
-        "starcraft"
-      ],
-      "preview_sounds": [
-        "SomebodyCallForAnExterminator.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "sc_goliath",
-      "display_name": "StarCraft Goliath",
-      "version": "1.0.0",
-      "description": "StarCraft 1 Terran Goliath unit voice lines",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 16,
-      "total_size_bytes": 586660,
-      "source_repo": "kschmidtjr1/openpeon-sc_goliath",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "38d718892738d0622667ec4389f49cb3b9a85b52416739e426c0328845697006",
-      "tags": [
-        "gaming",
-        "starcraft"
-      ],
-      "preview_sounds": [
-        "GoliathOnline.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "sc_kerrigan",
-      "display_name": "Sarah Kerrigan (StarCraft)",
-      "version": "1.0.0",
-      "description": "Sarah Kerrigan (StarCraft) sound pack from StarCraft",
-      "author": {
-        "name": "garysheng",
-        "github": "garysheng"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 16,
-      "total_size_bytes": 415163,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "sc_kerrigan",
-      "manifest_sha256": "e422c233bdff9e52efae1e3e17264b1eeea2060d212c84356191c6490aa5ea96",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "KerriganReporting.mp3",
-        "ImReady.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "sc_marine",
-      "display_name": "StarCraft Marine",
-      "version": "1.0.0",
-      "description": "StarCraft Marine sound pack — iconic lines including 'Rock 'n' roll!' and 'You want a piece of me, boy?'",
-      "author": {
-        "name": "harrymunro",
-        "github": "harrymunro"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 16,
-      "total_size_bytes": 329257,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.2.0",
-      "source_path": "sc_marine",
-      "manifest_sha256": "ff50155f9a8741268ca8d97ff8f8c65c7e7004e7faf1e71da5994f451066ffd6",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "YouWannaPieceOfMe.mp3",
-        "RockAndRoll.mp3"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "sc_medic",
-      "display_name": "StarCraft Medic",
-      "version": "2.0.0",
-      "description": "StarCraft Medic sound pack — 16 SC1 voice lines across all 7 CESP categories, featuring 'He's dead, Jim' and medical humor",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 16,
-      "total_size_bytes": 475901,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.3.0",
-      "source_path": "sc_medic",
-      "manifest_sha256": "635cab7ea7dffc208570da319edd9e4fd048900caa736f0af016a1ae8b6ab558",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PreppedAndReady.mp3",
-        "HesDeadJim.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "sc_raynor",
-      "display_name": "StarCraft Raynor",
-      "version": "1.0.0",
-      "description": "StarCraft 1 Terran Jim Raynor (Marine) voice lines",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 14,
-      "total_size_bytes": 324097,
-      "source_repo": "kschmidtjr1/openpeon-sc_raynor",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "96a0ff7712a5ddb6c2f49fc9d103b25c7ce8513d0d1b1cef72323da42f6a47fd",
-      "tags": [
-        "gaming",
-        "starcraft"
-      ],
-      "preview_sounds": [
-        "RaynorHere.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "sc_scv",
-      "display_name": "StarCraft SCV",
-      "version": "2.0.0",
-      "description": "StarCraft SCV sound pack — expanded with 19 sounds across all 7 CESP categories",
-      "author": {
-        "name": "harrymunro",
-        "github": "harrymunro"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 19,
-      "total_size_bytes": 414515,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.2.0",
-      "source_path": "sc_scv",
-      "manifest_sha256": "012352bc93f2f722fa2e39574e90ec488f8c827712c6da884966e07ea495a7ec",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "GoodToGoSir.mp3",
-        "GoodToGoSir.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "sc_tank",
-      "display_name": "StarCraft Siege Tank",
-      "version": "2.0.0",
-      "description": "StarCraft Siege Tank sound pack — 14 SC1 voice lines across all 7 CESP categories, featuring Ride of the Valkyries and 'drop the hammer'",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 14,
-      "total_size_bytes": 420226,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.3.0",
-      "source_path": "sc_tank",
-      "manifest_sha256": "e0bbef8c48dc7a4459b129bb9cd5c691bba8e98437c98482fa81079d0b6d2842",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ReadyToRollOut.mp3",
-        "RideOfTheValkyries.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-26"
-    },
-    {
-      "name": "sc_terran",
-      "display_name": "StarCraft Terran (All Units)",
-      "version": "1.0.0",
-      "description": "StarCraft Terran (All Units) sound pack from StarCraft",
-      "author": {
-        "name": "workdd",
-        "github": "workdd"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 17,
-      "total_size_bytes": 885414,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "sc_terran",
-      "manifest_sha256": "5afe83c6dddc3b317a79efdd14c43439c0543b005ab199697f78027d11c218b3",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ReadyToRollOut.mp3",
-        "GoodToGoSir.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "sc_vessel",
-      "display_name": "StarCraft Science Vessel",
-      "version": "1.0.0",
-      "description": "StarCraft Science Vessel sound pack from StarCraft",
-      "author": {
-        "name": "workdd",
-        "github": "workdd"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "input.required"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 6,
-      "total_size_bytes": 173504,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "sc_vessel",
-      "manifest_sha256": "f8c686baa9740362afc134b2fdd6935f5f26a7f567dcdea0378fa2526709f966",
-      "tags": [
-        "gaming",
-        "starcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ExplorerReporting.mp3",
-        "Affirmative.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "sc_vulture",
-      "display_name": "StarCraft Vulture",
-      "version": "1.0.0",
-      "description": "StarCraft 1 Terran Vulture voice lines",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 14,
-      "total_size_bytes": 469127,
-      "source_repo": "kschmidtjr1/openpeon-sc_vulture",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "b3d60f01cc6cb325cb2d5cb4237904df0585b296f07b8773e22c8651c3416693",
-      "tags": [
-        "gaming",
-        "starcraft"
-      ],
-      "preview_sounds": [
-        "AlrightBringItOn.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "sc_wraith",
-      "display_name": "StarCraft Wraith",
-      "version": "1.0.0",
-      "description": "StarCraft 1 Terran Wraith voice lines",
-      "author": {
-        "name": "kschmidtjr1",
-        "github": "kschmidtjr1"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 17,
-      "total_size_bytes": 484303,
-      "source_repo": "kschmidtjr1/openpeon-sc_wraith",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "be75e0049a286805eb666cf7e74b1fa156661314a1b343de6b0543212ee35fd4",
-      "tags": [
-        "gaming",
-        "starcraft"
-      ],
-      "preview_sounds": [
-        "WraithAwaitingLaunchOrders.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "sheogorath",
-      "display_name": "Sheogorath",
-      "version": "1.0.0",
-      "description": "Sheogorath sound pack from The Elder Scrolls",
-      "author": {
-        "name": "lloydaf",
-        "github": "lloydaf"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 41,
-      "total_size_bytes": 14615993,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "sheogorath",
-      "manifest_sha256": "2c25c16b8691d4ec5ada7120bf9be40d5705e9955b653da5f84d01b8283b8ce3",
-      "tags": [
-        "gaming",
-        "elder-scrolls",
-        "bethesda",
-        "rpg"
-      ],
-      "preview_sounds": [
-        "greeting_1.wav",
-        "complete_1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "silicon_valley",
-      "display_name": "Silicon Valley",
-      "version": "2.2.0",
-      "description": "Quotes from Silicon Valley — Erlich, Gilfoyle, Russ Hanneman, Jian Yang. English + Russian dubbed by «Кубик в кубике» (59 clips with swearing)",
-      "author": {
-        "name": "rustam",
-        "github": "fortunto2"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en,ru",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 64,
-      "total_size_bytes": 2168356,
-      "source_repo": "fortunto2/openpeon-silicon-valley",
-      "source_ref": "v2.2.0",
-      "source_path": ".",
-      "manifest_sha256": "3670d1b3dc682c8d665ca92b4aaf02b9b044607c2024ff76e5c2b469cc52d6cc",
-      "tags": [
-        "tv-show",
-        "comedy",
-        "silicon-valley",
-        "startup"
-      ],
-      "preview_sounds": [
-        "sounds/ThisGuyFucks.mp3",
-        "sounds/01_yobushki_vorobushki.mp3"
-      ],
-      "added": "2026-02-15",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "solid_snake",
-      "display_name": "Solid Snake",
-      "version": "1.0.0",
-      "description": "Tactical espionage audio - featuring the legendary Solid Snake from the Metal Gear Solid series",
-      "author": {
-        "name": "will",
-        "github": "wsturgiss"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 32,
-      "total_size_bytes": 1067760,
-      "source_repo": "wsturgiss/openpeon-solid-snake",
-      "source_ref": "v1.0.0",
-      "source_path": "",
-      "manifest_sha256": "0169b33580bbe22a02d9b3bdff1e73236d1532f53a1d538c944aaab169321cb9",
-      "tags": [
-        "gaming",
-        "metal-gear-solid",
-        "stealth",
-        "military",
-        "tactical"
-      ],
-      "preview_sounds": [
+    "version": 1,
+    "packs": [
         {
-          "file": "sounds/kept_you_waiting_mgs2.mp3",
-          "label": "Kept you waiting, huh?"
+            "name": "abbot",
+            "display_name": "The Abbot (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Abbot voice lines from Stronghold Crusader \u2014 scheming monastery lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 14,
+            "total_size_bytes": 440163,
+            "source_repo": "openpeon-stronghold/abbot",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "e36ef4bdbc2cbc1a676e083bd3baeca15fc98b983f37a3591f5a1a38f5d7594c",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "ab_add_player_01.mp3",
+                "ab_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
         },
         {
-          "file": "sounds/snake_roger_that.mp3",
-          "label": "Roger that"
+            "name": "acolyte_de",
+            "display_name": "Undead Acolyte (DE)",
+            "version": "1.0.0",
+            "description": "German Undead Acolyte sound pack from Warcraft III",
+            "author": {
+                "name": "Kaffeetasse",
+                "github": "Kaffeetasse"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "de",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 31,
+            "total_size_bytes": 2506838,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.1.0",
+            "source_path": "acolyte_de",
+            "manifest_sha256": "74d4953f5053c3d2f9423b7bd1af224a596d5d66d842951cd0d67ea0d31d2f34",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "AcolyteReady1.wav",
+                "AcolyteBuildingComplete1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
         },
         {
-          "file": "sounds/snake_what_the_hell.mp3",
-          "label": "What the hell?"
+            "name": "acolyte_es",
+            "display_name": "Ac\u00f3lito Muertos Vivientes Warcraft III (ES)",
+            "version": "1.0.2",
+            "description": "Spanish Undead Acolyte sound pack from Warcraft III",
+            "author": {
+                "name": "lurecas",
+                "github": "lurecas"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "es",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 29,
+            "total_size_bytes": 2197202,
+            "source_repo": "lurecas/openpeon-w3-acolyte-es",
+            "source_ref": "v1.0.2",
+            "source_path": "acolyte_es",
+            "manifest_sha256": "8a08bb9bdfadbb3a24601c51b4338c3fe0a5beba07c7ad59ba6354b60815cb18",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "AcolyteReady1.wav",
+                "AcolyteWhat1.wav"
+            ],
+            "added": "2026-02-16",
+            "updated": "2026-02-16"
+        },
+        {
+            "name": "acolyte_ru",
+            "display_name": "Undead Acolyte (Russian)",
+            "version": "1.0.0",
+            "description": "Undead Acolyte (Russian) sound pack from Warcraft III",
+            "author": {
+                "name": "maksimfedin",
+                "github": "maksimfedin"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "ru",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 30,
+            "total_size_bytes": 2984156,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "acolyte_ru",
+            "manifest_sha256": "c988eff118c207b8bd8f6902c0686e6f9e65a4901c215c8ae51b894546357a23",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "AcolyteReady1.wav",
+                "AcolyteBuildingComplete1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "ae_qianyu",
+            "display_name": "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730 \u9648\u5343\u8bed",
+            "version": "1.0.4",
+            "description": "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730 \u9648\u5343\u8bed \u8bed\u97f3\u5305",
+            "author": {
+                "name": "LiRiu",
+                "github": "LiRiu"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "zh-CN",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 9,
+            "total_size_bytes": 364120,
+            "source_repo": "LiRiu/qianyu-chen-pack",
+            "source_ref": "v1.0.4",
+            "source_path": ".",
+            "manifest_sha256": "50fd5866b2f025deba93723ceae9aa77ef88302efa7915711d881222c391d67b",
+            "tags": [
+                "gaming",
+                "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730",
+                "arknights:endfield"
+            ],
+            "preview_sounds": [
+                "new-1.mp3",
+                "dang-1.mp3",
+                "dang-2.mp3",
+                "dang-3.mp3"
+            ],
+            "added": "2026-02-15",
+            "updated": "2026-02-15"
+        },
+        {
+            "name": "afewgoodmen",
+            "display_name": "A Few Good Men",
+            "version": "1.0.1",
+            "description": "A Few Good Men quotes for your Claude Code notifications. 19 clips across 7 categories.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 19,
+            "total_size_bytes": 779377,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.1.1",
+            "source_path": "afewgoodmen",
+            "manifest_sha256": "e198f8aab308fe1f49324c880603a571ac2597a903a4092aba309fce56dd8efb",
+            "tags": [
+                "movie-quotes",
+                "drama",
+                "courtroom",
+                "jack-nicholson",
+                "tom-cruise"
+            ],
+            "preview_sounds": [
+                "kaffee_hi.mp3",
+                "kaffee_im_sorry.mp3"
+            ],
+            "added": "2026-02-26",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "airplane",
+            "display_name": "Airplane!",
+            "version": "1.0.1",
+            "description": "Airplane! quotes for your Claude Code notifications. 17 clips across 7 categories.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 17,
+            "total_size_bytes": 474374,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.1.1",
+            "source_path": "airplane",
+            "manifest_sha256": "b66478f685cd600c4f793b457d3dd96fc14cc2f11e6bf7e17fae21a506ecf043",
+            "tags": [
+                "movie-quotes",
+                "comedy",
+                "parody",
+                "leslie-nielsen",
+                "disaster-movie"
+            ],
+            "preview_sounds": [
+                "dont_call_me_shirley.mp3",
+                "johnny_jive.mp3"
+            ],
+            "added": "2026-02-26",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "anchorman_brick",
+            "display_name": "Brick Tamland",
+            "version": "1.0.0",
+            "description": "Non-sequiturs as a service.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 14,
+            "total_size_bytes": 309862,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "anchorman_brick",
+            "manifest_sha256": "169b4a1d476ceef5c020bb0ad044e43c52de3750d3d14d9f4bedf69430e794ab",
+            "tags": [
+                "movie-quotes",
+                "anchorman",
+                "comedy",
+                "steve-carell",
+                "brick-tamland",
+                "will-ferrell"
+            ],
+            "preview_sounds": [
+                "dont_know_what_yelling_about.mp3",
+                "fiberglass_insulation.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "anchorman_burgundy",
+            "display_name": "Ron Burgundy",
+            "version": "1.0.0",
+            "description": "San Diego's finest anchor, kind of a big deal.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 446242,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "anchorman_burgundy",
+            "manifest_sha256": "40c5ab35c2639b1897ba76bd0a92d1763c18f974cef9f8b837c23f20864f47ce",
+            "tags": [
+                "movie-quotes",
+                "anchorman",
+                "comedy",
+                "will-ferrell",
+                "ron-burgundy",
+                "san-diego"
+            ],
+            "preview_sounds": [
+                "by_the_beard_of_zeus.mp3",
+                "dont_act_like_youre_not_impressed.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "anchorman_news_team",
+            "display_name": "News Team",
+            "version": "1.0.0",
+            "description": "Channel 4 News Team Ensemble.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 10,
+            "total_size_bytes": 387527,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "anchorman_news_team",
+            "manifest_sha256": "3654c1c3ac5a2a6a86e4c15dd5dbe437155a055ccc302d5c721406340b41ea5d",
+            "tags": [
+                "movie-quotes",
+                "anchorman",
+                "comedy",
+                "will-ferrell",
+                "news-team",
+                "sex-panther"
+            ],
+            "preview_sounds": [
+                "dorothy_mantooth.mp3",
+                "its_called_sex_panther.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "aoe2",
+            "display_name": "Age of Empires II Taunts",
+            "version": "1.0.0",
+            "description": "Age of Empires II Taunts sound pack from Age of Empires II",
+            "author": {
+                "name": "halilb",
+                "github": "halilb"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 42,
+            "total_size_bytes": 630371,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "aoe2",
+            "manifest_sha256": "a1f0d0fb71166075a641c9f350d7f876e225c1b62627f5abc722b29d201b5dcd",
+            "tags": [
+                "gaming",
+                "age-of-empires",
+                "rts"
+            ],
+            "preview_sounds": [
+                "1-yes.mp3",
+                "1-yes.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "aoe4_fr_imperial",
+            "display_name": "Age of Empires IV - French Villager Voices",
+            "version": "1.0.2",
+            "description": "French villager voice lines from Age of Empires IV, extracted from the game files.",
+            "author": {
+                "name": "Guillaume et Louison",
+                "github": "ghusse"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 410,
+            "total_size_bytes": 16269304,
+            "source_repo": "ghusse/openpeon_sounds",
+            "source_ref": "v1.0.2",
+            "source_path": "aoe4-french-imperial",
+            "manifest_sha256": "137e9f5491725f961d0385a5bd985c1c2a72e0f8c986e817ca03131d4f82c535",
+            "tags": [
+                "gaming",
+                "age-of-empires",
+                "rts"
+            ],
+            "preview_sounds": [
+                "sounds/French_villagerfemale_select_ihigh_chigh_01_alt01_mp3.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "aom-greeks",
+            "display_name": "Age of Mythology - Greeks",
+            "version": "1.0.0",
+            "description": "Ancient Greek dialogue lines from Age of Mythology villagers, soldiers, and heroes",
+            "author": {
+                "name": "Konstantinos Diamantidis",
+                "github": "kdmnt"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "task.progress",
+                "user.spam",
+                "session.end"
+            ],
+            "language": "el",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 35,
+            "total_size_bytes": 380216,
+            "source_repo": "kdmnt/aom-greeks",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "c9dc36a7ce808a0215de8272edf6bd06acbcc3ab894b073d93d1e44a51ff9cfb",
+            "tags": [
+                "gaming",
+                "age-of-mythology",
+                "ancient-greek",
+                "greek"
+            ],
+            "preview_sounds": [
+                "villager-male-move-vulome.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "aom-italian",
+            "display_name": "Age of Mythology - Italian",
+            "version": "1.1.0",
+            "description": "Italian voice lines from Age of Mythology campaign: Arkantos, Ajax, Amanra, Kastor, Chirone and more",
+            "author": {
+                "name": "f-liva",
+                "github": "f-liva"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "task.progress",
+                "user.spam",
+                "session.end"
+            ],
+            "language": "it",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 64,
+            "total_size_bytes": 7163618,
+            "source_repo": "f-liva/openpeon-aom-italian",
+            "source_ref": "v1.1.0",
+            "source_path": ".",
+            "manifest_sha256": "d52d1512912348f98f01c1b7adc43d2d1ff151cdd30931c733fabc0aa45700e9",
+            "tags": [
+                "gaming",
+                "age-of-mythology",
+                "italian",
+                "rts"
+            ],
+            "preview_sounds": [
+                "arkantos-bene-cosi.wav",
+                "ajax-era-ora.wav"
+            ],
+            "added": "2026-02-27",
+            "updated": "2026-02-27"
+        },
+        {
+            "name": "aom_greek",
+            "display_name": "Age of Mythology - Greek Villager",
+            "version": "1.0.0",
+            "description": "Age of Mythology - Greek Villager sound pack from Age of Mythology",
+            "author": {
+                "name": "amitaifrey",
+                "github": "amitaifrey"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 20,
+            "total_size_bytes": 1211988,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "aom_greek",
+            "manifest_sha256": "c5a85333382a1008426048b063144f8e4e92cfbcaf58d99d6a4f6ced33645c46",
+            "tags": [
+                "gaming",
+                "age-of-mythology",
+                "rts"
+            ],
+            "preview_sounds": [
+                "Greeks_Villager_Male_Select_4_AoM.wav",
+                "Greeks_Villager_Male_Build_AoM.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "arc_raiders",
+            "display_name": "Arc Raiders Pack",
+            "version": "1.0.0",
+            "description": "Arc Raiders sound effects",
+            "author": {
+                "name": "A3mercury",
+                "github": "A3mercury"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "session.end"
+            ],
+            "language": "en",
+            "license": "MCC-BY-NC-4.0T",
+            "sound_count": 7,
+            "total_size_bytes": 1100000,
+            "source_repo": "A3mercury/openpeon-arcraiders",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "3df840bfb19b6815cfae30c0192c587d411b86e9d9b9fc7a63e0216848ed76ed",
+            "tags": [
+                "gaming",
+                "arc",
+                "goop"
+            ],
+            "preview_sounds": [
+                "TracingVictory.mp3",
+                "Blueprint.mp3"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "arnold",
+            "display_name": "Arnold Schwarzenegger",
+            "version": "1.0.0",
+            "description": "Iconic Arnold Schwarzenegger movie one-liners. Your terminal is now the Governator.",
+            "author": {
+                "name": "mmichael0413",
+                "github": "mmichael0413"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 15,
+            "total_size_bytes": 1131042,
+            "source_repo": "mmichael0413/openpeon-arnold",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "e2d59741a3c5b3dba64e923b90652dbcbf793f92a7d1452bfe4216fcfda618c6",
+            "tags": [
+                "movies",
+                "action",
+                "arnold",
+                "terminator"
+            ],
+            "preview_sounds": [
+                "ill-be-back.mp3",
+                "hasta-la-vista-baby.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "arthas_ru",
+            "display_name": "\u0410\u0440\u0442\u0430\u0441 \u0420\u044b\u0446\u0430\u0440\u044c \u0421\u043c\u0435\u0440\u0442\u0438 (Russian)",
+            "version": "1.0.0",
+            "description": "WC3 Death Knight Arthas \u2014 all 20 Russian voice lines mapped to CESP categories",
+            "author": {
+                "name": "samokay",
+                "github": "samokay"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "ru",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 20,
+            "total_size_bytes": 8633344,
+            "source_repo": "samokay/arthas_ru",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "391eec37a929112db5106a59809d4282f9c1071de110a09783baba7626ed3d85",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "russian",
+                "arthas",
+                "death-knight"
+            ],
+            "preview_sounds": [
+                "frostmourne_hungers.wav",
+                "for_the_lich_king.wav"
+            ],
+            "added": "2026-02-22",
+            "updated": "2026-02-22"
+        },
+        {
+            "name": "blues_brothers",
+            "display_name": "Blues Brothers",
+            "version": "1.0.0",
+            "description": "The full Blues Brothers experience.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 9,
+            "total_size_bytes": 568709,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "blues_brothers",
+            "manifest_sha256": "933cbfc67a9267825ba7e94e3db922bbeaac5b9887b1bc35a4ab8dfce4de2772",
+            "tags": [
+                "movie-quotes",
+                "the-blues-brothers",
+                "comedy",
+                "john-belushi",
+                "dan-aykroyd",
+                "blues",
+                "music"
+            ],
+            "preview_sounds": [
+                "106_test.mp3",
+                "band_is_back_together.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "blues_brothers_elwood",
+            "display_name": "Elwood Blues",
+            "version": "1.0.0",
+            "description": "Deadpan delivery, all business.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 11,
+            "total_size_bytes": 421572,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "blues_brothers_elwood",
+            "manifest_sha256": "102e9e841d843103ad998051b025bb74d3819e75db46588f2c98b0ae640a7c77",
+            "tags": [
+                "movie-quotes",
+                "the-blues-brothers",
+                "comedy",
+                "dan-aykroyd",
+                "elwood-blues",
+                "blues"
+            ],
+            "preview_sounds": [
+                "106_miles_to_chicago.mp3",
+                "cop_motor.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "blues_brothers_jake",
+            "display_name": "Jake Blues",
+            "version": "1.0.0",
+            "description": "Scheming, devout (sort of), on a mission from God.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 17,
+            "total_size_bytes": 731153,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "blues_brothers_jake",
+            "manifest_sha256": "df8fd54a41f647b338f60d6d274072b45f2f46b56ca7cc4e38ef49a8578164f1",
+            "tags": [
+                "movie-quotes",
+                "the-blues-brothers",
+                "comedy",
+                "john-belushi",
+                "jake-blues",
+                "blues"
+            ],
+            "preview_sounds": [
+                "are_you_the_police.mp3",
+                "band_is_back_together.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "brewmaster_ru",
+            "display_name": "Pandaren Brewmaster (Russian)",
+            "version": "1.0.0",
+            "description": "Pandaren Brewmaster (Russian) sound pack from Warcraft III",
+            "author": {
+                "name": "rubywwwilde",
+                "github": "rubywwwilde"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "ru",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 23,
+            "total_size_bytes": 2551528,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "brewmaster_ru",
+            "manifest_sha256": "f4e23ae91110b0beb9e241661c8a4bb659cf867f7e8ff1cf5f71528f96583c11",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "AnyoneWantBeer.mp3",
+                "OneMore.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "caliph",
+            "display_name": "The Caliph (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Caliph voice lines from Stronghold Crusader \u2014 diplomatic desert lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 411300,
+            "source_repo": "openpeon-stronghold/caliph",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "2b1528d2e6ba87583e95f8937f2f4b45fbfa293f6e3aa2b4625d49eeffed2a7d",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "ca_add_player_01.mp3",
+                "ca_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "cc_commando",
+            "display_name": "C&C: Commando",
+            "version": "1.0.1",
+            "description": "Command & Conquer Commando sound pack",
+            "author": {
+                "name": "shaneboulden",
+                "github": "shaneboulden"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 13,
+            "total_size_bytes": 169035,
+            "source_repo": "shaneboulden/openpeon-cc-commando",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "2e103bb35cdcd1d03b2c73e92b797b6dd7521effe2033ff1caa084a89b9fbd6d",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts",
+                "commando"
+            ],
+            "preview_sounds": [
+                "present-for-ya.mp3",
+                "left-handed.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "ccg_china_dozer",
+            "display_name": "C&C Generals: China Dozer",
+            "version": "1.0.1",
+            "description": "China dozer sound pack from Command & Conquer: Generals",
+            "author": {
+                "name": "YonahKarp",
+                "github": "YonahKarp"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 26,
+            "total_size_bytes": 1307964,
+            "source_repo": "YonahKarp/openpeon-ccg-china-dozer",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "a3bcaad00511b5036c0eccc12eef72c0bfa0318a1ff1dff4de98261547d1591c",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "A_very_good_plan_general.mp3",
+                "Construction_built_to_spec.mp3"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "ccg_gla_worker",
+            "display_name": "C&C Generals: GLA Worker",
+            "version": "1.0.1",
+            "description": "GLA worker sound pack from Command & Conquer: Generals",
+            "author": {
+                "name": "YonahKarp",
+                "github": "YonahKarp"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 37,
+            "total_size_bytes": 1613593,
+            "source_repo": "YonahKarp/openpeon-ccg-gla-worker",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "7e65595f1a858f52be4246f4c2c0fe22ee824de052bddb9d0b3766ed73798c2a",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "I_guess_I_should_help_out.mp3",
+                "All_work_is_complete.mp3"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "ccg_us_dozer",
+            "display_name": "C&C Generals: USA Dozer",
+            "version": "1.0.0",
+            "description": "USA dozer sound pack from Command & Conquer: Generals",
+            "author": {
+                "name": "YonahKarp",
+                "github": "YonahKarp"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 32,
+            "total_size_bytes": 1421229,
+            "source_repo": "YonahKarp/openpeon-ccg-us-dozer",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "da99a15d9fa3bafe9ebd97ba5f64257a1ba51a62c295c5604c118b21f29311fd",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "Lets_get_to_work.mp3",
+                "That_ones_done.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "charlie_sheen",
+            "display_name": "Charlie Sheen",
+            "version": "1.0.0",
+            "description": "Charlie Sheen's iconic interview quotes \u2014 Winning, tiger blood, and more.",
+            "author": {
+                "name": "rootbarb",
+                "github": "rootbarb"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 19,
+            "total_size_bytes": 16293980,
+            "source_repo": "rootbarb/openpeon-charlie-sheen",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "5e87469f61fd92ed8717d79b4f1fee3133bf78640c4addd44811da257db4dd92",
+            "tags": [
+                "celebrity",
+                "meme",
+                "interview"
+            ],
+            "preview_sounds": [
+                "Winning.wav"
+            ],
+            "added": "2026-02-16",
+            "updated": "2026-02-16"
+        },
+        {
+            "name": "clean_chimes",
+            "display_name": "Clean Chimes",
+            "version": "1.0.0",
+            "description": "Professional notification tones and chimes for a workspace-friendly experience",
+            "author": {
+                "name": "chris-halim",
+                "github": "chris-halim"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "Mixkit License",
+            "sound_count": 7,
+            "total_size_bytes": 2984006,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "main",
+            "source_path": "clean_chimes",
+            "manifest_sha256": "6c8caa737d8daf579899dd1f89da5ad513e85c55e7cea5cfa563acea6f8cb994",
+            "tags": [
+                "professional",
+                "minimal",
+                "notifications"
+            ],
+            "preview_sounds": [
+                "CC_Start.wav",
+                "CC_Complete.wav"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "cortana",
+            "display_name": "Cortana",
+            "version": "1.0.3",
+            "description": "Cortana from Halo",
+            "author": {
+                "name": "A3mercury",
+                "github": "A3mercury"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 11,
+            "total_size_bytes": 699000,
+            "source_repo": "A3mercury/openpeon-cortana",
+            "source_ref": "v1.0.3",
+            "source_path": ".",
+            "manifest_sha256": "f34e11d8e904411e4d7c6e84d49744b98557156d7cd6b66cc8e987d2f427da22",
+            "tags": [
+                "gaming",
+                "halo",
+                "cortana"
+            ],
+            "preview_sounds": [
+                "MissMe.mp3",
+                "Answer.mp3",
+                "AlreadyBegun.mp3",
+                "Scanning.mp3",
+                "Ride.mp3",
+                "LocatedPillar.mp3",
+                "ThreatLevel1.mp3",
+                "SleepWell.mp3",
+                "TakeTooLong.mp3",
+                "WhatAreYouDoing.mp3"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "counterstrike",
+            "display_name": "Counter-Strike",
+            "version": "1.0.2",
+            "description": "Classic Counter-Strike radio commands",
+            "author": {
+                "name": "colbyfayock",
+                "github": "colbyfayock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 15,
+            "total_size_bytes": 983040,
+            "source_repo": "colbyfayock/openpeon-counterstrike",
+            "source_ref": "v1.0.2",
+            "source_path": ".",
+            "manifest_sha256": "87189d450468f7f69bf25d0292a8f6c18366063e52f4875da7adf283ff428015",
+            "tags": [
+                "gaming",
+                "counterstrike",
+                "cs"
+            ],
+            "preview_sounds": [
+                "lock-and-load.wav",
+                "roger.wav"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "d2_deckard_cain",
+            "display_name": "Deckard Cain (Diablo 2)",
+            "version": "1.0.0",
+            "description": "Stay a while and listen! Deckard Cain voice lines from Diablo 2.",
+            "author": {
+                "name": "rootbarb",
+                "github": "rootbarb"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 14,
+            "total_size_bytes": 999232,
+            "source_repo": "rootbarb/openpeon-d2-deckard-cain",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "12971dd87e673276fa11bbb0fa1b695bcdfef4288cc85b6e137039099bf46158",
+            "tags": [
+                "gaming",
+                "diablo",
+                "blizzard",
+                "rpg"
+            ],
+            "preview_sounds": [
+                "StayAWhileAndListen.wav"
+            ],
+            "added": "2026-02-16",
+            "updated": "2026-02-16"
+        },
+        {
+            "name": "deadlock_dynamo",
+            "display_name": "Dynamo (Deadlock)",
+            "version": "1.0.0",
+            "description": "Dynamo voice pack from Valve's Deadlock",
+            "author": {
+                "name": "mwaterman29",
+                "github": "mwaterman29"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 48,
+            "total_size_bytes": 1038668,
+            "source_repo": "mwaterman29/openpeon-deadlock-dynamo",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "c1c983029329cf6e419086be004e3d4f4ccff2a7feefabfaf2eb49dac704d2de",
+            "tags": [
+                "gaming",
+                "deadlock",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "dynamo_select_06.mp3",
+                "dynamo_ping_good_job_01.mp3"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "deadpool",
+            "display_name": "Deadpool (2016)",
+            "version": "1.0.0",
+            "description": "Maximum effort! Audio clips from Deadpool (2016) featuring Ryan Reynolds' iconic one-liners.",
+            "author": {
+                "name": "victor",
+                "github": "xtrimsystems"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 35,
+            "total_size_bytes": 1267975,
+            "source_repo": "xtrimsystems/peon-ping-deadpool",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "cc44c05be18d5e8e050b19826d1ed1a805d7fb835da65b1e0183254f0b192759",
+            "tags": [
+                "movie",
+                "deadpool",
+                "marvel",
+                "comedy",
+                "ryan-reynolds"
+            ],
+            "preview_sounds": [
+                "sounds/Maximum_effort.mp3",
+                "sounds/I_m_touching_myself_tonight.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "diehard",
+            "display_name": "Die Hard",
+            "version": "1.0.1",
+            "description": "Die Hard quotes for your Claude Code notifications. 16 clips across 7 categories.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 832002,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.1.1",
+            "source_path": "diehard",
+            "manifest_sha256": "c397104fbb3c340922d34466414f8f1a6a42c40fbc7733a5abab7f1d1a7c075d",
+            "tags": [
+                "movie-quotes",
+                "action",
+                "christmas",
+                "bruce-willis",
+                "hans-gruber",
+                "alan-rickman"
+            ],
+            "preview_sounds": [
+                "powell_welcome_to_the_party.mp3",
+                "welcome_to_the_party.mp3"
+            ],
+            "added": "2026-02-26",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "dobby",
+            "display_name": "Dobby the House-Elf",
+            "version": "1.0.0",
+            "description": "Dobby is here to help! A house-elf themed sound pack for OpenCode featuring Dobby from Harry Potter.",
+            "author": {
+                "name": "johmara",
+                "github": "johmara"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.error",
+                "input.required"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 6,
+            "total_size_bytes": 2523948,
+            "source_repo": "johmara/openpeon-dobby",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "1e96f9b91fec1b71ce0516900b12d9ec8e27c029f46a7589888fcdefc3e0399b",
+            "tags": [
+                "movie",
+                "harry-potter",
+                "house-elf",
+                "fantasy"
+            ],
+            "preview_sounds": [
+                "sounds/dobby-hello.wav",
+                "sounds/dobby-done.wav"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "dota2_axe",
+            "display_name": "Axe (Dota 2)",
+            "version": "1.0.0",
+            "description": "Axe (Dota 2) sound pack from Dota 2",
+            "author": {
+                "name": "x-n2o",
+                "github": "x-n2o"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 20,
+            "total_size_bytes": 538432,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.3.0",
+            "source_path": "dota2_axe",
+            "manifest_sha256": "5c1dd1cdc3c1517ca7c554b9bab4b5ca22f99ba3cc625ec7e4c527bd266b28a8",
+            "tags": [
+                "gaming",
+                "dota2",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "AxeIsReady.mp3",
+                "AxeHappened.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "dota2_ember_spirit",
+            "display_name": "Ember Spirit (Dota 2)",
+            "version": "1.0.0",
+            "description": "Ember Spirit (Dota 2) sound pack \u2014 'Balance in all things.'",
+            "author": {
+                "name": "kmelkon",
+                "github": "kmelkon"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 26,
+            "total_size_bytes": 931168,
+            "source_repo": "kmelkon/openpeon-dota2",
+            "source_ref": "main",
+            "source_path": "dota2_ember_spirit",
+            "manifest_sha256": "14b9a86e260574aa3600569a015de55c04956c096c5139aeec8999c2f8a42fab",
+            "tags": [
+                "gaming",
+                "dota2",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "EmberSpirit.mp3",
+                "BalanceInAllThings.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "dota2_invoker",
+            "display_name": "Invoker (Dota 2)",
+            "version": "1.0.0",
+            "description": "Invoker (Dota 2) sound pack \u2014 'So begins a new age of knowledge.'",
+            "author": {
+                "name": "bwarren2",
+                "github": "bwarren2"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 24,
+            "total_size_bytes": 828573,
+            "source_repo": "bwarren2/peonpack-invoker",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "b1e8ea61f82d07332981d31e51b28dce4eb90beb5d369371149d99fe84210c3d",
+            "tags": [
+                "gaming",
+                "dota2",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "Invoker.mp3",
+                "GloriousInvocation.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "dota2_phantom_lancer",
+            "display_name": "Phantom Lancer (Dota 2)",
+            "version": "1.0.0",
+            "description": "Phantom Lancer (Dota 2) sound pack \u2014 'From one: an army.'",
+            "author": {
+                "name": "kmelkon",
+                "github": "kmelkon"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 28,
+            "total_size_bytes": 829847,
+            "source_repo": "kmelkon/openpeon-dota2",
+            "source_ref": "v1.0.0",
+            "source_path": "dota2_phantom_lancer",
+            "manifest_sha256": "d4db1490a124269e9b48198ab8625a44bfb8b803f9d25c6926bfc459ddb015d4",
+            "tags": [
+                "gaming",
+                "dota2",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "PhantomLancer.mp3",
+                "FromOneAnArmy.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "dota2_witch_doctor",
+            "display_name": "Witch Doctor (Dota 2)",
+            "version": "1.0.0",
+            "description": "Witch Doctor (Dota 2) sound pack \u2014 'De Doctor is in!'",
+            "author": {
+                "name": "kmelkon",
+                "github": "kmelkon"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 26,
+            "total_size_bytes": 899825,
+            "source_repo": "kmelkon/openpeon-dota2",
+            "source_ref": "main",
+            "source_path": "dota2_witch_doctor",
+            "manifest_sha256": "941b8a21b0eb4cd6003b803199cf273bf7fc33395b0ea60855efa046fbe8bf04",
+            "tags": [
+                "gaming",
+                "dota2",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "DeDoctorisIn.mp3",
+                "LookAtItGo.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "dota2_zeus",
+            "display_name": "Zeus (Dota 2)",
+            "version": "1.0.0",
+            "description": "Zeus (Dota 2) sound pack \u2014 'Your god has arrived.'",
+            "author": {
+                "name": "kmelkon",
+                "github": "kmelkon"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 34,
+            "total_size_bytes": 1219940,
+            "source_repo": "kmelkon/openpeon-dota2",
+            "source_ref": "main",
+            "source_path": "dota2_zeus",
+            "manifest_sha256": "333c7a4f7294842a9c849d0e84ecbe640d15e9674ae104ae040a7e3f3d1e8cc2",
+            "tags": [
+                "gaming",
+                "dota2",
+                "valve",
+                "moba"
+            ],
+            "preview_sounds": [
+                "Zeus.mp3",
+                "Thunderstruck.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "duke_nukem",
+            "display_name": "Duke Nukem",
+            "version": "1.0.0",
+            "description": "Duke Nukem sound pack from Duke Nukem",
+            "author": {
+                "name": "unknown",
+                "github": "unknown"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 24,
+            "total_size_bytes": 7737086,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "duke_nukem",
+            "manifest_sha256": "d31b4bc666904b66280606a16476a1db80d01a5077107611bd3ab81be21b1214",
+            "tags": [
+                "gaming",
+                "duke-nukem",
+                "fps",
+                "retro"
+            ],
+            "preview_sounds": [
+                "KickAssChewGum.wav",
+                "KaboomBaby.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "dva",
+            "display_name": "D.Va Overwatch",
+            "version": "1.0.0",
+            "description": "D.Va voice lines from Overwatch - includes Korean and English lines.",
+            "author": {
+                "name": "Leo",
+                "github": "leo-rutter"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.acknowledge",
+                "task.error",
+                "input.required"
+            ],
+            "language": "en",
+            "license": "MIT",
+            "sound_count": 17,
+            "total_size_bytes": 285750,
+            "source_repo": "leo-rutter/d.va-pack",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "94fe7bf6e6825d2a4dea378b49c00efff136d029b8a9b6d81b8e7afcbf4d256a",
+            "tags": [
+                "gaming",
+                "Blizzard",
+                "Overwatch"
+            ],
+            "preview_sounds": [
+                "dva-online.mp3",
+                "winky-face.mp3",
+                "gg.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "emir",
+            "display_name": "The Emir (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Emir voice lines from Stronghold Crusader \u2014 fierce Arabian lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 447740,
+            "source_repo": "openpeon-stronghold/emir",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "1f4ab98fd0cc0614f15836a7ad6fc17ea19d1fe9272bb991874f708cf496736a",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "em_add_player_01.mp3",
+                "em_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "eve-walle",
+            "display_name": "EVE (Wall-E)",
+            "version": "1.0.1",
+            "description": "Sound pack featuring EVE, the sleek probe robot from Pixar's Wall-E",
+            "author": {
+                "name": "stphnlngdn",
+                "github": "stphnlngdncoding"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 21,
+            "total_size_bytes": 2579136,
+            "source_repo": "stphnlngdncoding/eve-walle",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "c0ae34010e3a34b658ba5f6f90f790d5ebd9ed2852e1ef1d1c5a375161e2eeda",
+            "tags": [
+                "pixar",
+                "wall-e",
+                "robot",
+                "movie"
+            ],
+            "preview_sounds": [
+                "start1.wav",
+                "done1.wav"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "frederick",
+            "display_name": "Emperor Frederick (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "Emperor Frederick voice lines from Stronghold Crusader \u2014 noble crusader emperor",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 492354,
+            "source_repo": "openpeon-stronghold/frederick",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "ce79802bcd528a65c4d0d8d07efa1e4bb326180f0d7367fae542eaaaf9d01065",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "fr_add_player_01.mp3",
+                "fr_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "futurama_bender",
+            "display_name": "Bender (Futurama)",
+            "version": "1.0.0",
+            "description": "Bender Bending Rodriguez quotes from Futurama",
+            "author": {
+                "name": "ravenrs",
+                "github": "ravenrs"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 18,
+            "total_size_bytes": 778093,
+            "source_repo": "ravenrs/peon-ping-futurama-bender-",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "8a58349e2fa183a9cd8fa900ee5d7255cfd66f5e31f852441e4e420e3a97fa7b",
+            "tags": [
+                "futurama",
+                "bender",
+                "cartoon",
+                "robot",
+                "comedy"
+            ],
+            "preview_sounds": [
+                "time-for-this-robot-to-get-back-to-work.mp3",
+                "ah-crap.mp3"
+            ],
+            "added": "2026-02-16",
+            "updated": "2026-02-16"
+        },
+        {
+            "name": "gilfoyle",
+            "display_name": "Gilfoyle",
+            "version": "1.0.0",
+            "description": "Bertram Gilfoyle from Silicon Valley",
+            "author": {
+                "name": "mpospirit",
+                "github": "mpospirit"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam",
+                "session.end",
+                "task.progress"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 40,
+            "total_size_bytes": 38999632,
+            "source_repo": "mpospirit/openpeon-gilfoyle",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "a892ec40c4dc10d986cd120e09bf11474e7f6a1a5d2f09de7aac4554e730adf1",
+            "tags": [
+                "tv",
+                "silicon-valley",
+                "comedy"
+            ],
+            "added": "2026-02-27",
+            "updated": "2026-02-27"
+        },
+        {
+            "name": "glados",
+            "display_name": "GLaDOS (Portal)",
+            "version": "1.0.0",
+            "description": "GLaDOS (Portal) sound pack from Portal",
+            "author": {
+                "name": "DoubleGremlin181",
+                "github": "DoubleGremlin181"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 23,
+            "total_size_bytes": 1143346,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "glados",
+            "manifest_sha256": "1e6066a66018f56092b917ae36123f84278b1fb29979642cee664760a1549d8b",
+            "tags": [
+                "gaming",
+                "portal",
+                "valve",
+                "puzzle"
+            ],
+            "preview_sounds": [
+                "Hello.mp3",
+                "GoodNews.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "hal_2001",
+            "display_name": "HAL 9000 (2001: A Space Odyssey)",
+            "version": "1.0.0",
+            "description": "I'm sorry, Dave. I'm afraid I can't do that. Audio clips from HAL 9000 in 2001: A Space Odyssey.",
+            "author": {
+                "name": "jq",
+                "github": "jquintus"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 17,
+            "total_size_bytes": 721994,
+            "source_repo": "jquintus/openpeon-hal-2001",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "984aa115db965f6a8eedfad06757bf69060a501dc8b5a28092ddc3431ddbf228",
+            "tags": [
+                "sci-fi",
+                "movie",
+                "kubrick",
+                "hal9000",
+                "space"
+            ],
+            "preview_sounds": [
+                "open_the_pod_bay_doors_hal_sorry_dave.wav",
+                "good_evening.wav"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "hd2_helldiver",
+            "display_name": "Helldiver (Helldivers 2)",
+            "version": "1.0.0",
+            "description": "Helldiver (Helldivers 2) sound pack from Helldivers 2",
+            "author": {
+                "name": "ZachTaylor99",
+                "github": "ZachTaylor99"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 31,
+            "total_size_bytes": 616665,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "hd2_helldiver",
+            "manifest_sha256": "5b09c3c2ae878c99117b72a6fe444706a8e719caf95326a1878b229cbda6aa60",
+            "tags": [
+                "gaming",
+                "helldivers",
+                "shooter"
+            ],
+            "preview_sounds": [
+                "ReportingForDuty1.mp3",
+                "FoundSomething.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "jarvis",
+            "display_name": "J.A.R.V.I.S.",
+            "version": "1.0.0",
+            "description": "Just A Rather Very Intelligent System. Formal British AI assistant voice notifications with Daniel's voice, including Mr. Stark references.",
+            "author": {
+                "name": "Boke7",
+                "github": "Boke7"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en-GB",
+            "license": "MIT",
+            "sound_count": 29,
+            "total_size_bytes": 1789952,
+            "source_repo": "Boke7/peonping-jarvis",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "6410a3a4f75c80bbd093a40d7ca3d56457a8c3e9dca57067427ab6cab27c5622",
+            "tags": [
+                "british",
+                "formal",
+                "ai",
+                "marvel",
+                "tts",
+                "elevenlabs"
+            ],
+            "preview_sounds": [
+                "sounds/task_acknowledge_4.mp3",
+                "sounds/task_complete_4.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "kaamelott",
+            "display_name": "Kaamelott",
+            "version": "1.0.0",
+            "description": "Best of Kaamelott",
+            "author": {
+                "name": "rsylvian",
+                "github": "rsylvian"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-ND",
+            "sound_count": 16,
+            "total_size_bytes": 991511,
+            "source_repo": "rsylvian/openpeon-kaamelott",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "6d66d07ea4fc77f950c4b6bc63109728acaaed8adc8ea228d0945ed39e9f2fd9",
+            "tags": [
+                "kaamelott",
+                "french",
+                "comedy",
+                "tv-show"
+            ],
+            "preview_sounds": [
+                "trompette.mp3"
+            ],
+            "added": "2026-02-27",
+            "updated": "2026-02-27"
+        },
+        {
+            "name": "league_of_legends",
+            "display_name": "League of Legends",
+            "version": "1.0.0",
+            "description": "Iconic LoL announcer and ping sounds from Summoner's Rift",
+            "author": {
+                "name": "chris-halim",
+                "github": "chris-halim"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 11,
+            "total_size_bytes": 4566618,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "main",
+            "source_path": "league_of_legends",
+            "manifest_sha256": "8c43c51fe82215cf0bc51d8229b3e10b4884783042810e26ae3af2b2e16bffe9",
+            "tags": [
+                "gaming",
+                "league-of-legends",
+                "riot"
+            ],
+            "preview_sounds": [
+                "LOL_WelcomeToSR.wav",
+                "LOL_PentaKill.wav"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "lebowski_big_lebowski",
+            "display_name": "The Big Lebowski",
+            "version": "1.0.0",
+            "description": "Wealthy bluster and achievement-worship.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 13,
+            "total_size_bytes": 546568,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "lebowski_big_lebowski",
+            "manifest_sha256": "146622212b947c987d730c43495dac8ec1a058e6b518be4f88231252938c2110",
+            "tags": [
+                "movie-quotes",
+                "the-big-lebowski",
+                "comedy",
+                "coen-brothers",
+                "david-huddleston",
+                "big-lebowski"
+            ],
+            "preview_sounds": [
+                "achievers.mp3",
+                "are_you_employed_sir.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "lebowski_jesus",
+            "display_name": "Jesus Quintana",
+            "version": "1.0.0",
+            "description": "Nobody fucks with the Jesus. Maximum intimidation, minimum vocabulary.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 12,
+            "total_size_bytes": 294790,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "lebowski_jesus",
+            "manifest_sha256": "8575a783ecc51dced598f00666aa348223caa5dc04582820b2eab4378f9e5862",
+            "tags": [
+                "movie-quotes",
+                "the-big-lebowski",
+                "comedy",
+                "coen-brothers",
+                "john-turturro",
+                "jesus-quintana",
+                "bowling"
+            ],
+            "preview_sounds": [
+                "date_wednesday_baby.mp3",
+                "gonna_fuck_you_up.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "lebowski_maude",
+            "display_name": "Maude Lebowski",
+            "version": "1.0.0",
+            "description": "Intellectual condescension as a notification sound.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 10,
+            "total_size_bytes": 269108,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "lebowski_maude",
+            "manifest_sha256": "efea16ae441a213b1566d38291c94d588d0b393d122afcbdb14adbba949be45a",
+            "tags": [
+                "movie-quotes",
+                "the-big-lebowski",
+                "comedy",
+                "coen-brothers",
+                "julianne-moore",
+                "maude-lebowski"
+            ],
+            "preview_sounds": [
+                "dont_be_fatuous.mp3",
+                "good_man_and_thorough.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "lebowski_the_dude",
+            "display_name": "The Dude",
+            "version": "1.0.0",
+            "description": "The Dude abides... as your coding notification.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 21,
+            "total_size_bytes": 863177,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "lebowski_the_dude",
+            "manifest_sha256": "6b01199a41a160864fd59732819d56787a64ef616d84dbafe6af9e4fd92f010e",
+            "tags": [
+                "movie-quotes",
+                "the-big-lebowski",
+                "comedy",
+                "coen-brothers",
+                "jeff-bridges",
+                "the-dude",
+                "bowling"
+            ],
+            "preview_sounds": [
+                "aggression_will_not_stand.mp3",
+                "far_out_man.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "lebowski_walter",
+            "display_name": "Walter Sobchak",
+            "version": "1.0.0",
+            "description": "Unhinged Vietnam veteran energy for your coding errors.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 19,
+            "total_size_bytes": 713341,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "lebowski_walter",
+            "manifest_sha256": "81550d777d2ef679d79aff5728e0234e756efc549ce108e62f3f5a82d7379c50",
+            "tags": [
+                "movie-quotes",
+                "the-big-lebowski",
+                "comedy",
+                "coen-brothers",
+                "john-goodman",
+                "walter-sobchak",
+                "bowling"
+            ],
+            "preview_sounds": [
+                "calmer_than_you_are.mp3",
+                "dont_roll_on_shabbos.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "marcel",
+            "display_name": "Marcel",
+            "version": "1.0.0",
+            "description": "Legendary quotes of Marcel Mer\u010diak.",
+            "author": {
+                "name": "Mari\u00e1n \u010cam\u00e1k",
+                "github": "mcamak"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "sk",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 17,
+            "total_size_bytes": 332952,
+            "source_repo": "mcamak/openpeon-marcel",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "0f4128148ebbd46fa24a670fbb94c8f6e7c6c2ebf94b552a0b466ab83194f583",
+            "tags": [
+                "stress"
+            ],
+            "preview_sounds": [
+                "06_osemkrat-sa-nieco-pytam.mp3",
+                "16_preco-ste-ma-tak-zarezali-do-pici.mp3"
+            ],
+            "added": "2026-02-18",
+            "updated": "2026-02-18"
+        },
+        {
+            "name": "marshal",
+            "display_name": "The Marshal (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Marshal voice lines from Stronghold Crusader \u2014 loyal European lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 414691,
+            "source_repo": "openpeon-stronghold/marshal",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "6505b6ab2424ec877948343be3cad00be4575e5cdd4350a2af3120579f33add3",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "ma_add_player_01.mp3",
+                "ma_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "milujipraci",
+            "display_name": "Miluji Pr\u00e1ci",
+            "version": "1.0.0",
+            "description": "Legendary quotes of Lubo\u0161 fixing Lakato\u0161.",
+            "author": {
+                "name": "Franti\u0161ek Z\u00e1hora",
+                "github": "arguit"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.error",
+                "input.required"
+            ],
+            "language": "cs",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 30,
+            "total_size_bytes": 1917736,
+            "source_repo": "arguit/openpeon-milujipraci",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "4619e4ce72dc6d307e12f18c1ee22f3156c9790e57e1ea1ef33889a7176ba943",
+            "tags": [
+                "stress"
+            ],
+            "preview_sounds": [
+                "past-vedle-pasti-pico.mp3",
+                "ne-nenasadis-ho.mp3"
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "minecraft_villager",
+            "display_name": "Minecraft Villager",
+            "version": "1.0.1",
+            "description": "Villager sound pack from Minecraft.",
+            "author": {
+                "name": "Eric Ker\u00e4nen",
+                "github": "Mahamurahti"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 19,
+            "total_size_bytes": 118573,
+            "source_repo": "Mahamurahti/openpeon-minecraft-villager",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "16f5fc57cf0928dc2a3943c80fc41561ed5ad252b5b79a3537fa6dd9d6339217",
+            "tags": [
+                "gaming",
+                "minecraft",
+                "mojang"
+            ],
+            "preview_sounds": [
+                "villager_idle1.ogg",
+                "villager_accept1.ogg"
+            ],
+            "added": "2026-02-24",
+            "updated": "2026-02-24"
+        },
+        {
+            "name": "molag_bal",
+            "display_name": "Molag Bal",
+            "version": "1.0.0",
+            "description": "Molag Bal sound pack from The Elder Scrolls",
+            "author": {
+                "name": "lloydaf",
+                "github": "lloydaf"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 29,
+            "total_size_bytes": 25545048,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "molag_bal",
+            "manifest_sha256": "401792f309e0831b5995ff178a41785a3952682a769bca21fed34c018c743fca",
+            "tags": [
+                "gaming",
+                "elder-scrolls",
+                "bethesda",
+                "rpg"
+            ],
+            "preview_sounds": [
+                "greeting_1.wav",
+                "complete_1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "mr_meeseeks",
+            "display_name": "Mr. Meeseeks (Rick and Morty)",
+            "version": "1.0.0",
+            "description": "Look at me! Mr. Meeseeks voice lines from Rick and Morty. Can do!",
+            "author": {
+                "name": "kasperhendriks",
+                "github": "kasperhendriks"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.error",
+                "input.required"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 30,
+            "total_size_bytes": 1246342,
+            "source_repo": "kasperhendriks/openpeon-mrmeeseeks",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "94f038d50b963eefec3892a5dafef7930d5b23ec229fbefa1bd790e80965ca34",
+            "tags": [
+                "tv",
+                "animation",
+                "comedy",
+                "rick-and-morty"
+            ],
+            "preview_sounds": [
+                "sounds/im_mr_meeseeks_look_at_me.mp3",
+                "sounds/can_do.mp3",
+                "sounds/all_done.mp3"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "mullemeck",
+            "display_name": "Mulle Meck (SV)",
+            "version": "1.0.0",
+            "description": "Mulle meck is eager to build!",
+            "author": {
+                "name": "zyk",
+                "github": "zyk"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "session.end"
+            ],
+            "language": "sv",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 18,
+            "total_size_bytes": 330387,
+            "source_repo": "zyk/openpeon-mullemeck",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "80c6e90dd90033f41df6515006894c2d0d844dcd3d6c7ce857ade13993d8e1fd",
+            "tags": [
+                "gaming"
+            ],
+            "preview_sounds": [
+                "molijoxer_och_mojanger.mp3"
+            ],
+            "added": "2026-02-28",
+            "updated": "2026-02-28"
+        },
+        {
+            "name": "murloc",
+            "display_name": "Murloc",
+            "version": "1.0.0",
+            "description": "Murloc sound pack from Warcraft III",
+            "author": {
+                "name": "Ferror",
+                "github": "Ferror"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 7,
+            "total_size_bytes": 70354,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.1.0",
+            "source_path": "murloc",
+            "manifest_sha256": "e9b5c431d0fcc907d7992634c6636188d533fd7e90370018c803d89528680153",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard"
+            ],
+            "preview_sounds": [
+                "mrrgll.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "nizar",
+            "display_name": "Nizar (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "Nizar voice lines from Stronghold Crusader \u2014 cunning assassin lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 374791,
+            "source_repo": "openpeon-stronghold/nizar",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "38f7aecb0ced6dc5736565a4b31a48d995af376cd3dcc3efd63d6cffe200e63a",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "ni_add_player_01.mp3",
+                "ni_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "ocarina_of_time",
+            "display_name": "Ocarina of Time",
+            "version": "1.0.0",
+            "description": "Navi and friends from The Legend of Zelda: Ocarina of Time",
+            "author": {
+                "name": "kmostdiek-k",
+                "github": "kmostdiek-k"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 13,
+            "total_size_bytes": 755172,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.1.0",
+            "source_path": "ocarina_of_time",
+            "manifest_sha256": "56094abe0d6e975c7a05c48dd64ca2cb5dd33e543fa93611a3030f7835bffecb",
+            "tags": [
+                "gaming",
+                "zelda",
+                "nintendo"
+            ],
+            "preview_sounds": [
+                "OOT_Navi_Hello1.wav",
+                "OOT_Secret.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "office_space",
+            "display_name": "Office Space",
+            "version": "1.0.0",
+            "description": "Office Space ensemble - Milton, the Bobs, and more.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 12,
+            "total_size_bytes": 367520,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "office_space",
+            "manifest_sha256": "1856ba4c1099eedc40b29e2de5470c38b0de3c2b582eb3c94524d942d0bfd529",
+            "tags": [
+                "movie-quotes",
+                "office-space",
+                "comedy",
+                "mike-judge",
+                "milton",
+                "tps-reports",
+                "work"
+            ],
+            "preview_sounds": [
+                "believe_you_have_my_stapler.mp3",
+                "bob_slydell.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "office_space_lumbergh",
+            "display_name": "Bill Lumbergh",
+            "version": "1.0.0",
+            "description": "Yeah, that would be great.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 17,
+            "total_size_bytes": 713560,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "office_space_lumbergh",
+            "manifest_sha256": "67a264ec9d874bb969d9a165a59549493cf59f2d8414b5f62f26bf6832bc09ee",
+            "tags": [
+                "movie-quotes",
+                "office-space",
+                "comedy",
+                "mike-judge",
+                "gary-cole",
+                "bill-lumbergh",
+                "work",
+                "tps-reports"
+            ],
+            "preview_sounds": [
+                "come_in_on_saturday.mp3",
+                "come_in_on_sunday.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "office_space_peter",
+            "display_name": "Peter Gibbons",
+            "version": "1.0.0",
+            "description": "Corporate soul-death as notification sounds.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 768664,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "office_space_peter",
+            "manifest_sha256": "a68900afb212cca02038a4d67245e22b384dc8e836555d0bd9f685a08fcdc3bb",
+            "tags": [
+                "movie-quotes",
+                "office-space",
+                "comedy",
+                "mike-judge",
+                "ron-livingston",
+                "peter-gibbons",
+                "work"
+            ],
+            "preview_sounds": [
+                "case_of_the_mondays.mp3",
+                "dont_care_if_laid_off.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "omar",
+            "display_name": "Omar Little (The Wire)",
+            "version": "1.1.1",
+            "description": "Omar comin'. Iconic Omar Little lines from The Wire.",
+            "author": {
+                "name": "Taylan Aydinli",
+                "github": "taylan"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 32,
+            "total_size_bytes": 1075304,
+            "source_repo": "taylan/openpeon-omar",
+            "source_ref": "v1.1.1",
+            "source_path": ".",
+            "manifest_sha256": "74aab994a66bfa2ddca57acbc40e562dad8b9162319b765e7dbb49cbbc07e860",
+            "tags": [
+                "tv",
+                "the-wire",
+                "hbo"
+            ],
+            "preview_sounds": [
+                "come-at-the-king.mp3",
+                "indeed.mp3"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-03-01"
+        },
+        {
+            "name": "peasant",
+            "display_name": "Human Peasant",
+            "version": "1.0.0",
+            "description": "Human Peasant sound pack from Warcraft III",
+            "author": {
+                "name": "thomasKn",
+                "github": "thomasKn"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 25,
+            "total_size_bytes": 1310954,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peasant",
+            "manifest_sha256": "7b32349f0c2734edc739c022d8fe3185b7be8f59e15f70743564c597c3a11848",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.wav",
+                "PeasantReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peasant_cz",
+            "display_name": "Lidsk\u00fd roln\u00edk (CZ)",
+            "version": "1.0.0",
+            "description": "Lidsk\u00fd roln\u00edk (CZ) sound pack from Warcraft III",
+            "author": {
+                "name": "vojtabiberle",
+                "github": "vojtabiberle"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "cs",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 25,
+            "total_size_bytes": 1804107,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peasant_cz",
+            "manifest_sha256": "337d61b71f94d0d1fd35cd57ed3af6c9cb0597031f003259fd1b52df24b24245",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.wav",
+                "PeasantReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peasant_es",
+            "display_name": "Campesino Humano (ES)",
+            "version": "1.0.0",
+            "description": "Campesino Humano (ES) sound pack from Warcraft III",
+            "author": {
+                "name": "Keralin",
+                "github": "Keralin"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "es",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 25,
+            "total_size_bytes": 1342974,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peasant_es",
+            "manifest_sha256": "065d7800530edee7867d73cb0fd479df0ab8df2e187bf1e3f8a5366476b73dc7",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.wav",
+                "PeasantReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peasant_fr",
+            "display_name": "Paysan Humain (FR)",
+            "version": "1.0.0",
+            "description": "Paysan Humain (FR) sound pack from Warcraft III",
+            "author": {
+                "name": "thomasKn",
+                "github": "thomasKn"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 25,
+            "total_size_bytes": 1580126,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peasant_fr",
+            "manifest_sha256": "2662c8df5d454b554e1541b4a441d58f1620e9665a8a15388a07720e89ed31f6",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.wav",
+                "PeasantReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peasant_ru",
+            "display_name": "Human Peasant (Russian)",
+            "version": "1.0.0",
+            "description": "Human Peasant (Russian) sound pack from Warcraft III",
+            "author": {
+                "name": "maksimfedin",
+                "github": "maksimfedin"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "ru",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 18,
+            "total_size_bytes": 979198,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peasant_ru",
+            "manifest_sha256": "565dda4d4d90339f30e44a29b3456c3ca8e6228633cb64dba33b764ea6181db2",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.wav",
+                "PeasantWhat3.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon",
+            "display_name": "Orc Peon",
+            "version": "1.0.0",
+            "description": "Orc Peon sound pack from Warcraft III",
+            "author": {
+                "name": "tonyyont",
+                "github": "tonyyont"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 27,
+            "total_size_bytes": 872012,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peon",
+            "manifest_sha256": "565178cd55b46a66d443a9e8c001fa51926413d5e562677b43a5de2381c7fe8e",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonReady1.wav",
+                "PeonReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon_cz",
+            "display_name": "Or\u010d\u00ed pe\u00f3n (CZ)",
+            "version": "1.0.0",
+            "description": "Or\u010d\u00ed pe\u00f3n (CZ) sound pack from Warcraft III",
+            "author": {
+                "name": "vojtabiberle",
+                "github": "vojtabiberle"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "cs",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 27,
+            "total_size_bytes": 1295067,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peon_cz",
+            "manifest_sha256": "426491ade6b692805fde7425f80a5513b1c15ff54a65288765481328b859c186",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonReady1.wav",
+                "PeonReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon_de",
+            "display_name": "Orc Peon (DE)",
+            "version": "1.0.0",
+            "description": "German Orc Peon sound pack from Warcraft III",
+            "author": {
+                "name": "Kaffeetasse",
+                "github": "Kaffeetasse"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "de",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 27,
+            "total_size_bytes": 1013804,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.1.0",
+            "source_path": "peon_de",
+            "manifest_sha256": "2fd9c89497333efc0c1ddac317d23b0b715d7d29e9744f4105ee189b04253e57",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonReady1.wav",
+                "PeonYes3.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon_es",
+            "display_name": "Peon Orco (ES)",
+            "version": "1.0.0",
+            "description": "Peon Orco (ES) sound pack from Warcraft III",
+            "author": {
+                "name": "Keralin",
+                "github": "Keralin"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "es",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 27,
+            "total_size_bytes": 859036,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peon_es",
+            "manifest_sha256": "082b63a99d86a253dfc6e86061ea6723095a15bd525be0f7bebce803cc23b2f9",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonReady1.wav",
+                "PeonReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon_fr",
+            "display_name": "Peon Orc (FR)",
+            "version": "1.0.0",
+            "description": "Peon Orc (FR) sound pack from Warcraft III",
+            "author": {
+                "name": "thomasKn",
+                "github": "thomasKn"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 27,
+            "total_size_bytes": 971410,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peon_fr",
+            "manifest_sha256": "5c82c4b15252b96b123d6f8cf62efc98f62975196d2af14019a1b2a96c484c9b",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonReady1.wav",
+                "PeonReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon_pl",
+            "display_name": "Orc Peon (Polish)",
+            "version": "1.0.0",
+            "description": "Orc Peon (Polish) sound pack from Warcraft III",
+            "author": {
+                "name": "ArturSkowronski",
+                "github": "ArturSkowronski"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "pl",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 22,
+            "total_size_bytes": 4026800,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "peon_pl",
+            "manifest_sha256": "bdacb2d514f6e85609eebdcb77ad25ecc76a385d1f8929d16843c03c98480b12",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonWhat1.wav",
+                "PeonYes1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "peon_ru",
+            "display_name": "Orc Peon (Russian)",
+            "version": "1.0.0",
+            "description": "Orc Peon (Russian) sound pack from Warcraft III",
+            "author": {
+                "name": "maksimfedin",
+                "github": "maksimfedin"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "ru",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 25,
+            "total_size_bytes": 1117894,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.3.0",
+            "source_path": "peon_ru",
+            "manifest_sha256": "05b0076d2f5601f6bc9b6a493440b5e7b98d200b979e77a955e7f22d5b7aa886",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonReady1.wav",
+                "PeonReady1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "philip",
+            "display_name": "King Philip (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "King Philip voice lines from Stronghold Crusader \u2014 proud king of France",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 519760,
+            "source_repo": "openpeon-stronghold/philip",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "dbbe560a020abbc57d86b1eab0c7e0615191ae7fc7d2f925b46acc7ed2584e30",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "ph_add_player_01.mp3",
+                "ph_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "pig",
+            "display_name": "The Pig (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Pig voice lines from Stronghold Crusader \u2014 brutal villain lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 683058,
+            "source_repo": "openpeon-stronghold/pig",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "129c6f9c3ef0694103092fa26b02d817c566ed60c6c99c6eedf7fcf2ee5b1fec",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "pg_add_player.mp3",
+                "pg_taunt_04.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "postal2_pl",
+            "display_name": "Postal 2 (Polish)",
+            "version": "1.0.1",
+            "description": "Sounds from Postal 2 (Polish), mostly Dude.",
+            "author": {
+                "name": "deoomen",
+                "github": "deoomen"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "session.end",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "pl",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 25,
+            "total_size_bytes": 3977010,
+            "source_repo": "deoomen/openpeon-postal2_pl",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "e93d9bc3e100ce7e3bb5adc5a35d20fcee33e375b1cf76ab7556858bd0e79825",
+            "tags": [
+                "gaming",
+                "hardcore",
+                "mature",
+                "funny",
+                "postal"
+            ],
+            "preview_sounds": [
+                "sounds/Dude_RegretNothing2.wav",
+                "sounds/dude_sure.wav"
+            ],
+            "added": "2026-02-28",
+            "updated": "2026-02-28"
+        },
+        {
+            "name": "professor-layton",
+            "display_name": "Professor Layton",
+            "version": "1.0.0",
+            "description": "Every puzzle has an answer! SFX from Professor Layton and the Curious Village by Level-5.",
+            "author": {
+                "name": "Skyforce77",
+                "github": "skyforce77"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 6,
+            "total_size_bytes": 297416,
+            "source_repo": "skyforce77/openpeon-professor-layton",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "738a6a554ccbe514d5aed07d9d1e1dc02ea68f938c4694edd93a9f2604d46529",
+            "tags": [
+                "puzzle",
+                "gentleman",
+                "nintendo",
+                "level5",
+                "game",
+                "mystery"
+            ],
+            "preview_sounds": [
+                "sounds/puzzle_solved.mp3",
+                "sounds/hint_coin.mp3"
+            ],
+            "added": "2026-02-26",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "protoss",
+            "display_name": "Protoss (StarCraft)",
+            "version": "1.0.0",
+            "description": "StarCraft Protoss voice lines and sound effects \u2014 en taro Adun!",
+            "author": {
+                "name": "Cody Born",
+                "github": "codyborn"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 10,
+            "total_size_bytes": 316849,
+            "source_repo": "codyborn/protoss-sounds",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "2b94f5dbf942bc87bb47b8215965cc8e87b555f649f232ccc4ab1ced682f13a9",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "protoss",
+                "sci-fi"
+            ],
+            "preview_sounds": [
+                "sounds/protoss_carrier.mp3",
+                "sounds/protoss_pylons.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "ra2_eva_commander",
+            "display_name": "RA2 EVA Commander",
+            "version": "1.0.1",
+            "description": "Red Alert 2 Allied EVA commander voice lines mixed with Tanya responses.",
+            "author": {
+                "name": "zenvor",
+                "github": "zenvor"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam",
+                "session.end"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 23,
+            "total_size_bytes": 1369358,
+            "source_repo": "zenvor/openpeon-ra2-eva-commander",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "e219c745cb3e5704d39e075b24dee48b4a87f4e49947ee8bb4b6b9b6435f8bf2",
+            "tags": [
+                "gaming",
+                "red-alert",
+                "cnc",
+                "rts",
+                "eva"
+            ],
+            "preview_sounds": [
+                "battle-control-online.wav",
+                "yeah-baby.wav"
+            ],
+            "added": "2026-03-02",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "ra2_kirov",
+            "display_name": "RA2 Kirov Airship",
+            "version": "1.0.0",
+            "description": "RA2 Kirov Airship sound pack from Command & Conquer: Red Alert 2",
+            "author": {
+                "name": "i-zhirov",
+                "github": "i-zhirov"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 19,
+            "total_size_bytes": 367012,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "ra2_kirov",
+            "manifest_sha256": "2099a50bd9fa0db593981f80ac4141bffa4cd2626bd3d501fe32c82d7e472094",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "KirovReporting.mp3",
+                "BombardiersToYourStations.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "ra2_peon",
+            "display_name": "Red Alert 2 Voice Lines",
+            "version": "1.0.0",
+            "description": "Classic Red Alert 2 unit voice lines for coding feedback. From conscripts to Kirov airships, let Soviet and Allied forces narrate your coding session.",
+            "author": {
+                "name": "Emiel Verkade",
+                "github": "emielver"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.progress",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam",
+                "session.end"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 438,
+            "total_size_bytes": 3113236,
+            "source_repo": "emielver/ra2_peon",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "1f355a5809ebc4e7af77a891b04c4b47997f22f35242b3153fc74b244c5a7355",
+            "tags": [
+                "red-alert",
+                "rts",
+                "command-conquer",
+                "soviet",
+                "allied",
+                "military",
+                "gaming"
+            ],
+            "preview_sounds": [
+                "a-new-comrade-joins-us.mp3",
+                "acknowledged.mp3",
+                "cha-ching.mp3",
+                "comrade.mp3",
+                "conscript-reporting.mp3",
+                "kirov-reporting_1.mp3",
+                "kirov-reporting.mp3",
+                "orders-comrade.mp3",
+                "ready-comrade.mp3",
+                "yes-comrade.mp3"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "ra2_soviet_engineer",
+            "display_name": "RA2 Soviet Engineer",
+            "version": "1.0.0",
+            "description": "RA2 Soviet Engineer sound pack from Command & Conquer: Red Alert 2",
+            "author": {
+                "name": "msukkari",
+                "github": "msukkari"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 12,
+            "total_size_bytes": 58190,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "ra2_soviet_engineer",
+            "manifest_sha256": "bc588337d5dd0edfb86f0b9a727b45f2be826558dc99a4dcb3f2b2dd0718f28c",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ToolsReady.mp3",
+                "Engineering.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "ra2_yuri",
+            "display_name": "RA2 Yuri (Yuri's Revenge)",
+            "version": "1.0.0",
+            "description": "Yuri Prime & Yuri Clone sound pack from Command & Conquer: Red Alert 2 - Yuri's Revenge",
+            "author": {
+                "name": "testy-cool",
+                "github": "testy-cool"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 55,
+            "total_size_bytes": 3353696,
+            "source_repo": "testy-cool/openpeon-ra2-yuri",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "73afb91726904c3582b7013b1984938a27d77845fcd4090d71ba1705c7c2fc6b",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "iyupsea.wav",
+                "iyupcrd.wav"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "ra_soviet",
+            "display_name": "Red Alert Soviet Soldier",
+            "version": "1.0.0",
+            "description": "Red Alert Soviet Soldier sound pack from Command & Conquer: Red Alert",
+            "author": {
+                "name": "JairusKhan",
+                "github": "JairusKhan"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 36,
+            "total_size_bytes": 1239943,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "ra_soviet",
+            "manifest_sha256": "b61eac06505c37426c2e1a7e51ef64d1b15c0013b18bde5c9fa003990ce7bbf2",
+            "tags": [
+                "gaming",
+                "command-and-conquer",
+                "ea",
+                "rts"
+            ],
+            "preview_sounds": [
+                "SovietAwaitingOrders.wav",
+                "SovietReadyAndWaiting.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "rat",
+            "display_name": "The Rat (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Rat voice lines from Stronghold Crusader \u2014 scheming cowardly villain",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 881950,
+            "source_repo": "openpeon-stronghold/rat",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "035279c4036b51a3b9c59b9c90fbd35756641b47de4714f76bee1d15f4f21f91",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "rt_add_player.mp3",
+                "rt_taunt_03.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "richard",
+            "display_name": "King Richard (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "King Richard voice lines from Stronghold Crusader \u2014 noble English crusader king",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 17,
+            "total_size_bytes": 470547,
+            "source_repo": "openpeon-stronghold/richard",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "ae3fb2703f7128ea7371515a11ab89ba1384d0a733dd56b33cc242dd2d34dce0",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "ri_add_player_01.mp3",
+                "ri_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "rick",
+            "display_name": "Rick Sanchez",
+            "version": "1.0.0",
+            "description": "Rick Sanchez sound pack from Rick and Morty",
+            "author": {
+                "name": "ranjitp16",
+                "github": "ranjitp16"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 14,
+            "total_size_bytes": 420414,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "rick",
+            "manifest_sha256": "c0097725338aa6d9f308d1948dbb60600105f5c10f8329c091e5f974758e42e1",
+            "tags": [
+                "tv",
+                "animation",
+                "comedy"
+            ],
+            "preview_sounds": [
+                "Rick_Sanchez_Jerry_.mp3",
+                "Rick_Sanchez_Fun.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "saladin",
+            "display_name": "Saladin (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "Saladin voice lines from Stronghold Crusader \u2014 honourable sultan of Egypt",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 521774,
+            "source_repo": "openpeon-stronghold/saladin",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "040d7a7390858602c8bba8753bd4511f40f13d3a63e3390e4bb8533c3d84827e",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "sa_add_player_01.mp3",
+                "sa_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "sc2_carrier",
+            "display_name": "Carrier (StarCraft II)",
+            "version": "1.0.0",
+            "description": "Protoss Carrier unit voice lines from StarCraft II",
+            "author": {
+                "name": "Bryce Evans",
+                "github": "bryce-evans"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required"
+            ],
+            "language": "en",
+            "license": "Fair Use",
+            "sound_count": 7,
+            "total_size_bytes": 214331,
+            "source_repo": "bryce-evans/openpeon-sc2-carrier",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "6a55be29c99b933e022586fd929f48519db7d3bd4ac7c54f8e461d6eafc9dd2e",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "protoss",
+                "blizzard"
+            ],
+            "preview_sounds": [
+                "carrier-has-arrived.mp3",
+                "we-are-ready.ogg"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "sc2_stalker",
+            "display_name": "Stalker (StarCraft II)",
+            "version": "1.1.0",
+            "description": "Protoss Stalker voice lines from StarCraft II",
+            "author": {
+                "name": "Sergej Lopatkin",
+                "github": "selop"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam",
+                "session.end"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 26,
+            "total_size_bytes": 1504193,
+            "source_repo": "selop/peon-pack-stalker-sc2",
+            "source_ref": "v1.1.0",
+            "source_path": ".",
+            "manifest_sha256": "df48a1307e9568e2f1c6cfe4e0a1f8e70f79946285d1faca10f654a262824500",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "protoss",
+                "blizzard"
+            ],
+            "preview_sounds": [
+                "you-require-my-skills.mp3",
+                "i-serve-for-now.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-15"
+        },
+        {
+            "name": "sc_battlecruiser",
+            "display_name": "StarCraft Battlecruiser",
+            "version": "1.0.0",
+            "description": "StarCraft Battlecruiser sound pack from StarCraft",
+            "author": {
+                "name": "garysheng",
+                "github": "garysheng"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 13,
+            "total_size_bytes": 423109,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "sc_battlecruiser",
+            "manifest_sha256": "70ea29abbb0b380def6cebda44af2d06e7191e6ee90565e4119cf0a4df472b50",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "BattlecruiserOperational.mp3",
+                "HailingFrequenciesOpen.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "sc_dropship",
+            "display_name": "StarCraft Dropship",
+            "version": "1.0.0",
+            "description": "StarCraft 1 Terran Dropship voice lines",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 16,
+            "total_size_bytes": 555313,
+            "source_repo": "kschmidtjr1/openpeon-sc_dropship",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "91fc44d0ebc43b0d80d9a467a040ef8144e7485b99c57ef8a989d14947fce035",
+            "tags": [
+                "gaming",
+                "starcraft"
+            ],
+            "preview_sounds": [
+                "CanITakeYourOrder.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sc_firebat",
+            "display_name": "StarCraft Firebat",
+            "version": "2.0.0",
+            "description": "StarCraft Firebat sound pack \u2014 17 SC1 voice lines across all 7 CESP categories, featuring 'Need a light?' and propane references",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 17,
+            "total_size_bytes": 544489,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.3.0",
+            "source_path": "sc_firebat",
+            "manifest_sha256": "1820390815ee8f591608b2fda4c6990de121b6f35bacb856ed6bdf17b6dd14e0",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "NeedALight.mp3",
+                "FireItUp.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "sc_ghost",
+            "display_name": "StarCraft Ghost",
+            "version": "1.0.0",
+            "description": "StarCraft 1 Terran Ghost unit voice lines",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 15,
+            "total_size_bytes": 505532,
+            "source_repo": "kschmidtjr1/openpeon-sc_ghost",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "5a9aefc59e38a37984f4ac1368679711bd5d7b6ed1615ce3617a67fd6227cd4e",
+            "tags": [
+                "gaming",
+                "starcraft"
+            ],
+            "preview_sounds": [
+                "SomebodyCallForAnExterminator.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sc_goliath",
+            "display_name": "StarCraft Goliath",
+            "version": "1.0.0",
+            "description": "StarCraft 1 Terran Goliath unit voice lines",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 16,
+            "total_size_bytes": 586660,
+            "source_repo": "kschmidtjr1/openpeon-sc_goliath",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "38d718892738d0622667ec4389f49cb3b9a85b52416739e426c0328845697006",
+            "tags": [
+                "gaming",
+                "starcraft"
+            ],
+            "preview_sounds": [
+                "GoliathOnline.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sc_kerrigan",
+            "display_name": "Sarah Kerrigan (StarCraft)",
+            "version": "1.0.0",
+            "description": "Sarah Kerrigan (StarCraft) sound pack from StarCraft",
+            "author": {
+                "name": "garysheng",
+                "github": "garysheng"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 16,
+            "total_size_bytes": 415163,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "sc_kerrigan",
+            "manifest_sha256": "e422c233bdff9e52efae1e3e17264b1eeea2060d212c84356191c6490aa5ea96",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "KerriganReporting.mp3",
+                "ImReady.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "sc_marine",
+            "display_name": "StarCraft Marine",
+            "version": "1.0.0",
+            "description": "StarCraft Marine sound pack \u2014 iconic lines including 'Rock 'n' roll!' and 'You want a piece of me, boy?'",
+            "author": {
+                "name": "harrymunro",
+                "github": "harrymunro"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 16,
+            "total_size_bytes": 329257,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.2.0",
+            "source_path": "sc_marine",
+            "manifest_sha256": "ff50155f9a8741268ca8d97ff8f8c65c7e7004e7faf1e71da5994f451066ffd6",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "YouWannaPieceOfMe.mp3",
+                "RockAndRoll.mp3"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "sc_medic",
+            "display_name": "StarCraft Medic",
+            "version": "2.0.0",
+            "description": "StarCraft Medic sound pack \u2014 16 SC1 voice lines across all 7 CESP categories, featuring 'He's dead, Jim' and medical humor",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 16,
+            "total_size_bytes": 475901,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.3.0",
+            "source_path": "sc_medic",
+            "manifest_sha256": "635cab7ea7dffc208570da319edd9e4fd048900caa736f0af016a1ae8b6ab558",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PreppedAndReady.mp3",
+                "HesDeadJim.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "sc_raynor",
+            "display_name": "StarCraft Raynor",
+            "version": "1.0.0",
+            "description": "StarCraft 1 Terran Jim Raynor (Marine) voice lines",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 14,
+            "total_size_bytes": 324097,
+            "source_repo": "kschmidtjr1/openpeon-sc_raynor",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "96a0ff7712a5ddb6c2f49fc9d103b25c7ce8513d0d1b1cef72323da42f6a47fd",
+            "tags": [
+                "gaming",
+                "starcraft"
+            ],
+            "preview_sounds": [
+                "RaynorHere.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sc_scv",
+            "display_name": "StarCraft SCV",
+            "version": "2.0.0",
+            "description": "StarCraft SCV sound pack \u2014 expanded with 19 sounds across all 7 CESP categories",
+            "author": {
+                "name": "harrymunro",
+                "github": "harrymunro"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 19,
+            "total_size_bytes": 414515,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.2.0",
+            "source_path": "sc_scv",
+            "manifest_sha256": "012352bc93f2f722fa2e39574e90ec488f8c827712c6da884966e07ea495a7ec",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "GoodToGoSir.mp3",
+                "GoodToGoSir.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "sc_tank",
+            "display_name": "StarCraft Siege Tank",
+            "version": "2.0.0",
+            "description": "StarCraft Siege Tank sound pack \u2014 14 SC1 voice lines across all 7 CESP categories, featuring Ride of the Valkyries and 'drop the hammer'",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 14,
+            "total_size_bytes": 420226,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.3.0",
+            "source_path": "sc_tank",
+            "manifest_sha256": "e0bbef8c48dc7a4459b129bb9cd5c691bba8e98437c98482fa81079d0b6d2842",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ReadyToRollOut.mp3",
+                "RideOfTheValkyries.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-26"
+        },
+        {
+            "name": "sc_terran",
+            "display_name": "StarCraft Terran (All Units)",
+            "version": "1.0.0",
+            "description": "StarCraft Terran (All Units) sound pack from StarCraft",
+            "author": {
+                "name": "workdd",
+                "github": "workdd"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 17,
+            "total_size_bytes": 885414,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "sc_terran",
+            "manifest_sha256": "5afe83c6dddc3b317a79efdd14c43439c0543b005ab199697f78027d11c218b3",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ReadyToRollOut.mp3",
+                "GoodToGoSir.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "sc_vessel",
+            "display_name": "StarCraft Science Vessel",
+            "version": "1.0.0",
+            "description": "StarCraft Science Vessel sound pack from StarCraft",
+            "author": {
+                "name": "workdd",
+                "github": "workdd"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "input.required"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 6,
+            "total_size_bytes": 173504,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "sc_vessel",
+            "manifest_sha256": "f8c686baa9740362afc134b2fdd6935f5f26a7f567dcdea0378fa2526709f966",
+            "tags": [
+                "gaming",
+                "starcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ExplorerReporting.mp3",
+                "Affirmative.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "sc_vulture",
+            "display_name": "StarCraft Vulture",
+            "version": "1.0.0",
+            "description": "StarCraft 1 Terran Vulture voice lines",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 14,
+            "total_size_bytes": 469127,
+            "source_repo": "kschmidtjr1/openpeon-sc_vulture",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "b3d60f01cc6cb325cb2d5cb4237904df0585b296f07b8773e22c8651c3416693",
+            "tags": [
+                "gaming",
+                "starcraft"
+            ],
+            "preview_sounds": [
+                "AlrightBringItOn.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sc_wraith",
+            "display_name": "StarCraft Wraith",
+            "version": "1.0.0",
+            "description": "StarCraft 1 Terran Wraith voice lines",
+            "author": {
+                "name": "kschmidtjr1",
+                "github": "kschmidtjr1"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 17,
+            "total_size_bytes": 484303,
+            "source_repo": "kschmidtjr1/openpeon-sc_wraith",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "be75e0049a286805eb666cf7e74b1fa156661314a1b343de6b0543212ee35fd4",
+            "tags": [
+                "gaming",
+                "starcraft"
+            ],
+            "preview_sounds": [
+                "WraithAwaitingLaunchOrders.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sheogorath",
+            "display_name": "Sheogorath",
+            "version": "1.0.0",
+            "description": "Sheogorath sound pack from The Elder Scrolls",
+            "author": {
+                "name": "lloydaf",
+                "github": "lloydaf"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 41,
+            "total_size_bytes": 14615993,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "sheogorath",
+            "manifest_sha256": "2c25c16b8691d4ec5ada7120bf9be40d5705e9955b653da5f84d01b8283b8ce3",
+            "tags": [
+                "gaming",
+                "elder-scrolls",
+                "bethesda",
+                "rpg"
+            ],
+            "preview_sounds": [
+                "greeting_1.wav",
+                "complete_1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "sheriff",
+            "display_name": "The Sheriff (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Sheriff voice lines from Stronghold Crusader \u2014 greedy corrupt villain",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 17,
+            "total_size_bytes": 514215,
+            "source_repo": "openpeon-stronghold/sheriff",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "c82e3003339938097eddd95a0e5af808db60eaa4d7e36bf755f643538750c3b4",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "sh_add_player_01.mp3",
+                "sh_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "silicon_valley",
+            "display_name": "Silicon Valley",
+            "version": "2.2.0",
+            "description": "Quotes from Silicon Valley \u2014 Erlich, Gilfoyle, Russ Hanneman, Jian Yang. English + Russian dubbed by \u00ab\u041a\u0443\u0431\u0438\u043a \u0432 \u043a\u0443\u0431\u0438\u043a\u0435\u00bb (59 clips with swearing)",
+            "author": {
+                "name": "rustam",
+                "github": "fortunto2"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en,ru",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 64,
+            "total_size_bytes": 2168356,
+            "source_repo": "fortunto2/openpeon-silicon-valley",
+            "source_ref": "v2.2.0",
+            "source_path": ".",
+            "manifest_sha256": "3670d1b3dc682c8d665ca92b4aaf02b9b044607c2024ff76e5c2b469cc52d6cc",
+            "tags": [
+                "tv-show",
+                "comedy",
+                "silicon-valley",
+                "startup"
+            ],
+            "preview_sounds": [
+                "sounds/ThisGuyFucks.mp3",
+                "sounds/01_yobushki_vorobushki.mp3"
+            ],
+            "added": "2026-02-15",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "snake",
+            "display_name": "The Snake (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Snake voice lines from Stronghold Crusader \u2014 treacherous villain lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 597564,
+            "source_repo": "openpeon-stronghold/snake",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "2b29eeb8d8be88fb5f1b098c92d6b4d7f69e1caad491d24223feab538ee9702f",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "sn_add_player.mp3",
+                "sn_taunt_02.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "solid_snake",
+            "display_name": "Solid Snake",
+            "version": "1.0.0",
+            "description": "Tactical espionage audio - featuring the legendary Solid Snake from the Metal Gear Solid series",
+            "author": {
+                "name": "will",
+                "github": "wsturgiss"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 32,
+            "total_size_bytes": 1067760,
+            "source_repo": "wsturgiss/openpeon-solid-snake",
+            "source_ref": "v1.0.0",
+            "source_path": "",
+            "manifest_sha256": "0169b33580bbe22a02d9b3bdff1e73236d1532f53a1d538c944aaab169321cb9",
+            "tags": [
+                "gaming",
+                "metal-gear-solid",
+                "stealth",
+                "military",
+                "tactical"
+            ],
+            "preview_sounds": [
+                {
+                    "file": "sounds/kept_you_waiting_mgs2.mp3",
+                    "label": "Kept you waiting, huh?"
+                },
+                {
+                    "file": "sounds/snake_roger_that.mp3",
+                    "label": "Roger that"
+                },
+                {
+                    "file": "sounds/snake_what_the_hell.mp3",
+                    "label": "What the hell?"
+                }
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "sopranos",
+            "display_name": "Tony Soprano",
+            "version": "1.0.0",
+            "description": "Tony Soprano sound pack from The Sopranos",
+            "author": {
+                "name": "voider1",
+                "github": "voider1"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 32,
+            "total_size_bytes": 811088,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "sopranos",
+            "manifest_sha256": "d1aab572caf4818ae6c5412742c59da67927d7f3cadff2376f932c65fc18f841",
+            "tags": [
+                "tv",
+                "drama",
+                "hbo"
+            ],
+            "preview_sounds": [
+                "Greeting_HiItsMe.mp3",
+                "Complete_Oooooh.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "southpark-fr",
+            "display_name": "South Park Fr",
+            "version": "1.0.0",
+            "description": "Sons issus de la bo\u00eete \u00e0 South Park (VF Game One)",
+            "author": {
+                "name": "Cl\u00e9ment",
+                "github": "Telmalk"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam",
+                "session.end"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 44,
+            "total_size_bytes": 2020601,
+            "source_repo": "Telmalk/peonping-southpark-fr",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "4a2d3f8aa8f8180dc4f527efea2e43c134bc9f09df64592013cca075ab6ada07",
+            "tags": [
+                "south-park",
+                "french",
+                "comedy",
+                "tv"
+            ],
+            "preview_sounds": [
+                "sounds/howdy.mp3",
+                "sounds/respectemonautorite.mp3",
+                "sounds/ilsonttue.mp3"
+            ],
+            "added": "2026-02-18",
+            "updated": "2026-02-18"
+        },
+        {
+            "name": "speaki",
+            "display_name": "Petite Speaki",
+            "version": "1.0.0",
+            "description": "Petite Speaki voice pack from Trickcal Chibi Go \u2014 adorable Korean character sounds for your coding sessions",
+            "author": {
+                "name": "cjna",
+                "github": "CJNA"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "ko",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 13,
+            "total_size_bytes": 1104000,
+            "source_repo": "CJNA/peon-ping-speaki",
+            "source_ref": "v1.0.0",
+            "source_path": "speaki",
+            "manifest_sha256": "e7d1a1cbd02e04143e8f0029863b67caaf074d86f7da42b9273846773f2d4822",
+            "tags": [
+                "gaming",
+                "trickcal",
+                "chibi",
+                "korean",
+                "kawaii"
+            ],
+            "preview_sounds": [
+                {
+                    "file": "sounds/session_start/speaki_hello.mp3",
+                    "label": "Speaki says hello!"
+                },
+                {
+                    "file": "sounds/task_acknowledge/hai.mp3",
+                    "label": "Hai! Got it!"
+                }
+            ],
+            "added": "2026-02-17",
+            "updated": "2026-02-17"
+        },
+        {
+            "name": "st_worf",
+            "display_name": "Worf (Star Trek)",
+            "version": "1.0.2",
+            "description": "Worf (Star Trek) sound pack from Star Trek",
+            "author": {
+                "name": "OmegaZero",
+                "github": "OmegaZero"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "MIT",
+            "sound_count": 12,
+            "total_size_bytes": 458221,
+            "source_repo": "OmegaZero/openpeon-worf",
+            "source_ref": "v1.0.2",
+            "source_path": ".",
+            "manifest_sha256": "3c521f4b0e6f9c70e05366ddf9e2c91c1e9f01e3aea0e15978904fceb218b164",
+            "tags": [
+                "television",
+                "star-trek"
+            ],
+            "preview_sounds": [
+                "HailingOpen.wav",
+                "WheresCaptain.wav"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "starrail-kafka-peon-pack",
+            "display_name": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
+            "version": "1.0.1",
+            "description": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
+            "author": {
+                "name": "0w0miki",
+                "github": "0w0miki"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "session.end",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "zh",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 22,
+            "total_size_bytes": 7709704,
+            "source_repo": "0w0miki/starrail-Kafka-peon-pack",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "0bac778f75f0443251f717341116b3edea5ee69aaa7de42df919706c4f7a6ce8",
+            "tags": [
+                "gaming",
+                "starrail"
+            ],
+            "preview_sounds": [
+                "hi.wav",
+                "time-end.wav"
+            ],
+            "added": "2026-02-23",
+            "updated": "2026-02-23"
+        },
+        {
+            "name": "starship_rasczak",
+            "display_name": "Lt. Rasczak",
+            "version": "1.0.0",
+            "description": "Grizzled teacher-turned-warrior tough love.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 10,
+            "total_size_bytes": 423370,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "starship_rasczak",
+            "manifest_sha256": "d0bd5e48ae57656f527117eac36c1a2387bc8555ba7617964dcd14f791b3250f",
+            "tags": [
+                "movie-quotes",
+                "starship-troopers",
+                "sci-fi",
+                "action",
+                "michael-ironside",
+                "rasczak",
+                "military"
+            ],
+            "preview_sounds": [
+                "civilian_vs_citizen.mp3",
+                "come_on_you_apes.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "starship_rico",
+            "display_name": "Johnny Rico",
+            "version": "1.0.0",
+            "description": "Gung-ho military propaganda energy for your code.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 17,
+            "total_size_bytes": 461806,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "starship_rico",
+            "manifest_sha256": "29c6311f481a726b676e54933d6d363d848d1a2991e45f73524e1c1e0cc11ca2",
+            "tags": [
+                "movie-quotes",
+                "starship-troopers",
+                "sci-fi",
+                "action",
+                "casper-van-dien",
+                "johnny-rico",
+                "military"
+            ],
+            "preview_sounds": [
+                "buenos_aires_kill_em_all.mp3",
+                "for_all_you_new_people.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "sultan",
+            "display_name": "The Sultan (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Sultan voice lines from Stronghold Crusader \u2014 powerful desert sultan",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 530804,
+            "source_repo": "openpeon-stronghold/sultan",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "8451d16dd09680ce7876631a0f64fbe12064d5fa2ea279b8ea8e2afe885e3b79",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "su_add_player_01.mp3",
+                "su_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "super_troopers",
+            "display_name": "Super Troopers",
+            "version": "1.0.0",
+            "description": "Vermont highway patrol chaos.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 14,
+            "total_size_bytes": 615432,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "super_troopers",
+            "manifest_sha256": "0315d8ad7af938867770fd2f8579b222a0fe3503420c700e75c9ed9711e611b6",
+            "tags": [
+                "movie-quotes",
+                "super-troopers",
+                "comedy",
+                "broken-lizard",
+                "meow",
+                "highway-patrol"
+            ],
+            "preview_sounds": [
+                "chicken_fucker.mp3",
+                "desperation_stinky_cologne.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "super_troopers_farva",
+            "display_name": "Farva",
+            "version": "1.0.0",
+            "description": "The coworker nobody asked for.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 8,
+            "total_size_bytes": 363768,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "super_troopers_farva",
+            "manifest_sha256": "406bc52767dc60e2e685dec9798e4409ba8ff0b28bd90faa7de9dac8aa4e66bc",
+            "tags": [
+                "movie-quotes",
+                "super-troopers",
+                "comedy",
+                "broken-lizard",
+                "kevin-heffernan",
+                "farva",
+                "liter-of-cola"
+            ],
+            "preview_sounds": [
+                "car_ramrod.mp3",
+                "goddamn_liter_of_cola.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "tekken3_announcer",
+            "display_name": "Announcer (Tekken 3)",
+            "version": "1.0.0",
+            "description": "Tekken 3 announcer voice lines \u2014 Fight, K.O., You win!, and more.",
+            "author": {
+                "name": "rootbarb",
+                "github": "rootbarb"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 12,
+            "total_size_bytes": 839060,
+            "source_repo": "rootbarb/openpeon-tekken3-announcer",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "04f73b1e90ad8eda7d9f5a5e31d6306fbc12a33e2af41bd8a4c85364cc21ef91",
+            "tags": [
+                "gaming",
+                "tekken",
+                "fighting",
+                "namco"
+            ],
+            "preview_sounds": [
+                "Fight.wav"
+            ],
+            "added": "2026-02-16",
+            "updated": "2026-02-16"
+        },
+        {
+            "name": "tf2_demoman",
+            "display_name": "TF2 Demoman",
+            "version": "1.0.0",
+            "description": "TF2 Demoman sound pack from Team Fortress 2",
+            "author": {
+                "name": "Breadcat",
+                "github": "thebreadcat"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "session.end",
+                "task.acknowledge",
+                "task.progress",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 67,
+            "total_size_bytes": 2920947,
+            "source_repo": "thebreadcat/openpeon-tf2-demoman",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "5fe0b7ea4e1b0f4e6486403400b714f7d186a456e62ff210691626ed33f1a1f0",
+            "tags": [
+                "gaming",
+                "tf2",
+                "valve",
+                "fps"
+            ],
+            "preview_sounds": [
+                "demoman_battlecry01.mp3",
+                "demoman_goodjob01.mp3",
+                "demoman_autoonfire01.mp3"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "tf2_engineer",
+            "display_name": "TF2 Engineer",
+            "version": "1.0.0",
+            "description": "TF2 Engineer sound pack from Team Fortress 2",
+            "author": {
+                "name": "Arie",
+                "github": "Arie"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 51,
+            "total_size_bytes": 1381445,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "tf2_engineer",
+            "manifest_sha256": "69f13fbf23b45ea515a90f032ae5ee2a1b05b0490d546acbbd2d8c0508cade35",
+            "tags": [
+                "gaming",
+                "tf2",
+                "valve",
+                "fps"
+            ],
+            "preview_sounds": [
+                "Engineer_battlecry01.mp3",
+                "Eng_quest_complete_easy_01.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "tf2_heavy",
+            "display_name": "TF2 Heavy",
+            "version": "1.0.0",
+            "description": "TF2 Heavy sound pack from Team Fortress 2",
+            "author": {
+                "name": "Breadcat",
+                "github": "thebreadcat"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "session.end",
+                "task.acknowledge",
+                "task.progress",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 113,
+            "total_size_bytes": 5222535,
+            "source_repo": "thebreadcat/tf2-heavy-pack",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "3bf5c407fa3bd703762d4de2e9ab6eb6d92cf8283d69e6b6cbcdfdc9a8cc6c4c",
+            "tags": [
+                "gaming",
+                "tf2",
+                "valve",
+                "fps",
+                "heavy"
+            ],
+            "preview_sounds": [
+                "heavy_go01.mp3",
+                "heavy_thanks01.mp3",
+                "heavy_goodjob02.mp3",
+                "heavy_battlecry03.mp3"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "tf2_pyro",
+            "display_name": "TF2 Pyro",
+            "version": "1.0.1",
+            "description": "TF2 Pyro sound pack from Team Fortress 2",
+            "author": {
+                "name": "Breadcat",
+                "github": "thebreadcat"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "session.end",
+                "task.acknowledge",
+                "task.progress",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 27,
+            "total_size_bytes": 5222535,
+            "source_repo": "thebreadcat/tf2-pyro-pack",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "b3ec6b5fd7b309b065fe330195d75d7d64e33790a6f1a05e36392c90265977d3",
+            "tags": [
+                "gaming",
+                "tf2",
+                "valve",
+                "fps",
+                "heavy"
+            ],
+            "preview_sounds": [
+                "pyro_battlecry01.mp3",
+                "pyro_thanks01.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "tf2_sniper",
+            "display_name": "TF2 Sniper",
+            "version": "1.0.0",
+            "description": "TF2 Sniper sound pack from Team Fortress 2",
+            "author": {
+                "name": "Breadcat",
+                "github": "thebreadcat"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "session.end",
+                "task.acknowledge",
+                "task.progress",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 56,
+            "total_size_bytes": 2920947,
+            "source_repo": "thebreadcat/tf2-sniper-pack",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "b7139a7c340f5dd9eafe08656989fe6539e961fee190c1fac82bf1e4321d9104",
+            "tags": [
+                "gaming",
+                "tf2",
+                "valve",
+                "fps"
+            ],
+            "preview_sounds": [
+                "sniper_battlecry03.mp3",
+                "sniper_cheers05.mp3",
+                "sniper_jaratetoss01.mp3"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "tf2_spy",
+            "display_name": "TF2 Spy",
+            "version": "1.0.0",
+            "description": "TF2 Spy sound pack from Team Fortress 2",
+            "author": {
+                "name": "Breadcat",
+                "github": "thebreadcat"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 37,
+            "total_size_bytes": 1381445,
+            "source_repo": "thebreadcat/openpeon-tf2-spy",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "a0d2c3ef0251197eba1feb5ea417e9dd381d7010871f274f9cbe4f01a81e59d0",
+            "tags": [
+                "gaming",
+                "tf2",
+                "valve",
+                "fps"
+            ],
+            "preview_sounds": [
+                "gentlemen.mp3",
+                "cheers-doctor.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "the-big-lebowski",
+            "display_name": "The Big Lebowski",
+            "version": "1.0.1",
+            "description": "The Dude abides. Iconic lines from The Big Lebowski.",
+            "author": {
+                "name": "Taylan Aydinli",
+                "github": "taylan"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 160,
+            "total_size_bytes": 6095239,
+            "source_repo": "taylan/openpeon-the-big-lebowski",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "ee46fe2e0c838f65737e306d51c1f2e37ba2f3177e543c4540e029f1a0292f2d",
+            "tags": [
+                "movie",
+                "comedy",
+                "coen-brothers"
+            ],
+            "preview_sounds": [
+                "001-the-dude-abides.mp3",
+                "103-shut-the-fuck-up-donny.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-01"
+        },
+        {
+            "name": "totally-spies-fr",
+            "display_name": "Totally spies (FR)",
+            "version": "1.0.1",
+            "description": "Best of Totally Spies (FR): Jerry, Clover, Sam & Alex <3",
+            "author": {
+                "name": "Capucine R.",
+                "github": "capucineROHART"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-ND",
+            "sound_count": 17,
+            "total_size_bytes": 1479709,
+            "source_repo": "capucineROHART/openpeon-totally-spies-fr",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "ea6d4f9e0dd5e250bd7ea4968919600bd84feb4de3d5b1e550045e86b30eaf79",
+            "tags": [
+                "badies",
+                "spies"
+            ],
+            "preview_sounds": [
+                "compowder.mp3",
+                "bonjour_mesdemoiselles.mp3"
+            ],
+            "added": "2026-02-18",
+            "updated": "2026-02-18"
+        },
+        {
+            "name": "warcraft-peon",
+            "display_name": "Warcraft 3 Peon",
+            "version": "1.0.0",
+            "description": "Warcraft 3 Peon sounds for OpenPeon",
+            "author": {
+                "name": "rocktane",
+                "github": "rocktane"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "task.complete"
+            ],
+            "language": "fr",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 1,
+            "total_size_bytes": 13431,
+            "source_repo": "rocktane/openpeon-warcraft-peon",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "e3bd17476b26de2cf51580991cec5ceb2c8c6db78e8f53e3b43f9ab18baaace7",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "task-complete.mp3"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "warcraft3-czech",
+            "display_name": "Warcraft III - Czech Peasant & Knight",
+            "version": "1.0.0",
+            "description": "Warcraft III Peasant & Knight sound alerts for Claude Code. Czech dubbed voices from the iconic RTS. Hur\u00e1\u00e1\u00e1\u00e1 do pr\u00e1ce!",
+            "author": {
+                "name": "Tomas Pflanzer",
+                "github": "gizmax"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.acknowledge",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "cs",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 5,
+            "total_size_bytes": 350324,
+            "source_repo": "gizmax/claude-code-wc3-sounds",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "5cce63a853aee7832224c8f33bb184e6cde937d4074cbac158431f55f94a1433",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts",
+                "czech",
+                "nostalgia"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.wav",
+                "PeasantBuildingComplete1.wav"
+            ],
+            "added": "2026-02-18",
+            "updated": "2026-02-18"
+        },
+        {
+            "name": "warcraft3-mix",
+            "display_name": "Warcraft III Mix CZ",
+            "version": "1.0.0",
+            "description": "Mix ikonick\u00fdch \u010desk\u00fdch hl\u00e1\u0161ek z Warcraft III od r\u016fzn\u00fdch jednotek a hrdin\u016f.",
+            "author": {
+                "name": "SgtMarmite",
+                "github": "SgtMarmite"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "cs",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 225,
+            "total_size_bytes": 17949988,
+            "source_repo": "SgtMarmite/peonping-warcraft3-mix",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "9f2ab8a55ee27ea1bef2c897242c4252133470c87a7cb96bd1e05c62530a7f3a",
+            "tags": [
+                "warcraft",
+                "warcraft3",
+                "blizzard",
+                "mix",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeonWhat4.wav",
+                "ArthasYes1.wav"
+            ],
+            "added": "2026-02-24",
+            "updated": "2026-02-24"
+        },
+        {
+            "name": "wazir",
+            "display_name": "The Wazir (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Wazir voice lines from Stronghold Crusader \u2014 scheming Arabian lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 16,
+            "total_size_bytes": 443110,
+            "source_repo": "openpeon-stronghold/wazir",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "0b79f4d5aa61528b04880f33c27bffdfd9f2ef6100ae8f5821fe92596c2ef673",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "wa_add_player_01.mp3",
+                "wa_willattack_01.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "wc2_human_ships",
+            "display_name": "WC2 Human Ships",
+            "version": "1.0.0",
+            "description": "Human naval unit voice lines from Warcraft II: Tides of Darkness",
+            "author": {
+                "name": "dmnd",
+                "github": "dmnd"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 22,
+            "total_size_bytes": 168954,
+            "source_repo": "dmnd/peonping-wc2_human_ships",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "a6c7d3f3ee21ae56fbc19a88d0ddf7e9a4b232e71eb30b529e0b621228dc1766",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "human1.wav",
+                "acknowledge1.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "wc2_peasant",
+            "display_name": "WC2 Peasant",
+            "version": "1.0.0",
+            "description": "WC2 Peasant sound pack from Warcraft II",
+            "author": {
+                "name": "sebbeth",
+                "github": "sebbeth"
+            },
+            "trust_tier": "official",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 21,
+            "total_size_bytes": 167005,
+            "source_repo": "PeonPing/og-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "wc2_peasant",
+            "manifest_sha256": "dcaea0f2fbbd8b5da5717c86604cf3dc401dc35b09fdfe512cf9f19279d32d06",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ReadyToServe.mp3",
+                "JobsDone.mp3"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "wc2_peasant_pt-br",
+            "display_name": "WC2 Human Peasant (PT-BR)",
+            "version": "1.1.1",
+            "description": "Human Peasant voice lines from WarCraft II dubbed in Brazilian Portuguese",
+            "author": {
+                "name": "Lucas Oliveira",
+                "github": "lucaspwo"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "pt-BR",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 18,
+            "total_size_bytes": 206180,
+            "source_repo": "lucaspwo/openpeon-wc2-peasant-pt-br",
+            "source_ref": "v1.1.1",
+            "source_path": ".",
+            "manifest_sha256": "52bf0298116a357a67a0d7aeb522dd1571366fab8990a1fe97b39453b74b4d18",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ReadyToServe.mp3",
+                "WorkComplete.mp3"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "wc2_sapper",
+            "display_name": "WC2 Goblin Sappers",
+            "version": "1.0.0",
+            "description": "The shrill sounds of goblin sappers from Warcraft II",
+            "author": {
+                "name": "anwilk",
+                "github": "anwilk"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 12,
+            "total_size_bytes": 300000,
+            "source_repo": "anwilk/openpeon-wc2_sapper",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "0c4f32f3f7fb771e087bba50ad60d0f6ba2c2d4219e52b7e7664ba8b998f9434",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "ready.wav",
+                "beautiful.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "wc3_corrupted_arthas",
+            "display_name": "Corrupted Arthas (WarCraft 3)",
+            "version": "1.0.3",
+            "description": "Corrupted Arthas (WarCraft 3) sound pack from WarCraft 3",
+            "author": {
+                "name": "OmegaZero",
+                "github": "OmegaZero"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "MIT",
+            "sound_count": 15,
+            "total_size_bytes": 3610314,
+            "source_repo": "OmegaZero/openpeon-corrupted-arthas",
+            "source_ref": "v1.0.3",
+            "source_path": ".",
+            "manifest_sha256": "31ba5d39f59d3cb63921b2f6927b5e58953ee51b6917d3eec08e51398383476e",
+            "tags": [
+                "gaming",
+                "warcraft3",
+                "rts"
+            ],
+            "preview_sounds": [
+                "SpeakFool.wav",
+                "WhatIsItNow.wav"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "wc3_jaina",
+            "display_name": "Jaina Proudmore (WarCraft 3)",
+            "version": "1.0.0",
+            "description": "Jaina Proudmore (WarCraft 3) sound pack from WarCraft 3",
+            "author": {
+                "name": "OmegaZero",
+                "github": "OmegaZero"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "MIT",
+            "sound_count": 13,
+            "total_size_bytes": 1052426,
+            "source_repo": "OmegaZero/openpeon-jaina",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "cde6367b42906933d72ecdae706ab9217ac9f382c407cb41ef62b3eb89598b47",
+            "tags": [
+                "gaming",
+                "warcraft3",
+                "rts"
+            ],
+            "preview_sounds": [
+                "JainaCanHelp.wav",
+                "JainaWhatsThePlan.wav"
+            ],
+            "added": "2026-02-12",
+            "updated": "2026-02-12"
+        },
+        {
+            "name": "wc3_peasant_pt-br",
+            "display_name": "WC3 Human Peasant (PT-BR)",
+            "version": "1.0.1",
+            "description": "Human Peasant voice lines from WarCraft III dubbed in Brazilian Portuguese",
+            "author": {
+                "name": "Lucas Oliveira",
+                "github": "lucaspwo"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "pt-BR",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 21,
+            "total_size_bytes": 364120,
+            "source_repo": "lucaspwo/open-peon-war3PT_BR",
+            "source_ref": "v1.0.1",
+            "source_path": ".",
+            "manifest_sha256": "fbe43123e4c5a1e730c2245799b9942a347678e025341d7f955e92ac101a12e6",
+            "tags": [
+                "gaming",
+                "warcraft",
+                "blizzard",
+                "rts"
+            ],
+            "preview_sounds": [
+                "PeasantReady1.mp3",
+                "PeasantBuildingComplete1.mp3"
+            ],
+            "added": "2026-02-14",
+            "updated": "2026-02-14"
+        },
+        {
+            "name": "wolf",
+            "display_name": "The Wolf (Stronghold Crusader)",
+            "version": "1.2.0",
+            "description": "The Wolf voice lines from Stronghold Crusader \u2014 ruthless villain lord",
+            "author": {
+                "name": "Marko Jevic",
+                "github": "koyev"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 474837,
+            "source_repo": "openpeon-stronghold/wolf",
+            "source_ref": "v1.2.0",
+            "source_path": ".",
+            "manifest_sha256": "4f8422d4bf80c2bc3fe77a995500aba6f4e563a245e13bfb21ed66c75c24a393",
+            "tags": [
+                "gaming",
+                "stronghold",
+                "rts",
+                "firefly"
+            ],
+            "preview_sounds": [
+                "wf_add_player.mp3",
+                "wf_taunt_05.mp3"
+            ],
+            "added": "2026-03-01",
+            "updated": "2026-03-02"
+        },
+        {
+            "name": "wolf-et-pack",
+            "display_name": "Wolf:ET Pack",
+            "version": "1.0.0",
+            "description": "Wolfenstein: Enemy Territory HQ command voiceovers \u2014 Allied and Axis variants",
+            "author": {
+                "name": "Graham Mackie",
+                "github": "gmackie"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 186,
+            "total_size_bytes": 22234324,
+            "source_repo": "gmackie/wolf-et-pack",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "23e34efeaf2238d3aface0c2a4c85f6af6440fac57fe42375919feda5c0f4ba4",
+            "tags": [
+                "gaming",
+                "fps",
+                "wolfenstein",
+                "splash-damage"
+            ],
+            "preview_sounds": [
+                "sounds/ack/allies/hq_dynplanted_a.wav",
+                "sounds/complete/allies/hq_objdest.wav"
+            ],
+            "added": "2026-02-13",
+            "updated": "2026-02-13"
+        },
+        {
+            "name": "worms-armageddon",
+            "display_name": "Worms Armageddon",
+            "version": "1.0.0",
+            "description": "Classic voice samples from Worms Armageddon featuring the iconic British worm taunts and exclamations",
+            "author": {
+                "name": "Mina Tawadrous",
+                "github": "mtmac17"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.error",
+                "input.required"
+            ],
+            "language": "en",
+            "license": "MIT",
+            "sound_count": 14,
+            "total_size_bytes": 179678,
+            "source_repo": "mtmac17/openpeon-worms-armageddon",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "d596c5402477d614746f7e1b4c9f904dabfbe786fdf5ebab22e3909ac2e12ef5",
+            "tags": [
+                "gaming",
+                "strategy",
+                "worms",
+                "team17",
+                "comedy"
+            ],
+            "preview_sounds": [
+                "sounds/greeting-hello.wav",
+                "sounds/done-excellent.wav"
+            ],
+            "added": "2026-02-19",
+            "updated": "2026-02-19"
+        },
+        {
+            "name": "zelda-a-link-to-the-past",
+            "display_name": "Zelda: A Link to the Past Sound Pack",
+            "version": "1.0.0",
+            "description": "Selected sound effects, jingles and music snippets from The Legend of Zelda: A Link to the Past",
+            "author": {
+                "name": "Henning Rokling",
+                "github": "hrokling"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 24,
+            "total_size_bytes": 24227328,
+            "source_repo": "hrokling/zelda-a-link-to-the-past",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "48387e8e22951872eb81249a73e1a259161ce2b355e979c0fb79d9f7fc7caa4c",
+            "tags": [
+                "zelda",
+                "nintendo",
+                "retro",
+                "game"
+            ],
+            "preview_sounds": [
+                "sounds/secret.wav",
+                "sounds/fairy.wav"
+            ],
+            "added": "2026-02-20",
+            "updated": "2026-02-20"
+        },
+        {
+            "name": "zoolander_derek",
+            "display_name": "Derek Zoolander",
+            "version": "1.0.0",
+            "description": "Really, really, ridiculously good looking notifications.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 15,
+            "total_size_bytes": 439011,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "zoolander_derek",
+            "manifest_sha256": "5e87d587f5c921ac4923978627de599d52bcfa6bf7cbf9c92173c38e0249b280",
+            "tags": [
+                "movie-quotes",
+                "zoolander",
+                "comedy",
+                "ben-stiller",
+                "derek-zoolander",
+                "blue-steel",
+                "male-models"
+            ],
+            "preview_sounds": [
+                "but_why_male_models.mp3",
+                "but_why_male_models_1.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
+        },
+        {
+            "name": "zoolander_hansel",
+            "display_name": "Hansel",
+            "version": "1.0.0",
+            "description": "So hot right now.",
+            "author": {
+                "name": "Willow Billock",
+                "github": "MattBillock"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 13,
+            "total_size_bytes": 453569,
+            "source_repo": "MattBillock/openpeon-movie-packs",
+            "source_ref": "v1.0.0",
+            "source_path": "zoolander_hansel",
+            "manifest_sha256": "87f049012873b6637ffa8907dac80c36695504ab5a06f9143cc4b6d38ab37c24",
+            "tags": [
+                "movie-quotes",
+                "zoolander",
+                "comedy",
+                "owen-wilson",
+                "hansel",
+                "so-hot-right-now"
+            ],
+            "preview_sounds": [
+                "excuse_me_bro.mp3",
+                "gasoline_fight_accident.mp3"
+            ],
+            "added": "2026-02-25",
+            "updated": "2026-02-25"
         }
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "sopranos",
-      "display_name": "Tony Soprano",
-      "version": "1.0.0",
-      "description": "Tony Soprano sound pack from The Sopranos",
-      "author": {
-        "name": "voider1",
-        "github": "voider1"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 32,
-      "total_size_bytes": 811088,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "sopranos",
-      "manifest_sha256": "d1aab572caf4818ae6c5412742c59da67927d7f3cadff2376f932c65fc18f841",
-      "tags": [
-        "tv",
-        "drama",
-        "hbo"
-      ],
-      "preview_sounds": [
-        "Greeting_HiItsMe.mp3",
-        "Complete_Oooooh.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "southpark-fr",
-      "display_name": "South Park Fr",
-      "version": "1.0.0",
-      "description": "Sons issus de la boîte à South Park (VF Game One)",
-      "author": {
-        "name": "Clément",
-        "github": "Telmalk"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam",
-        "session.end"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 44,
-      "total_size_bytes": 2020601,
-      "source_repo": "Telmalk/peonping-southpark-fr",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "4a2d3f8aa8f8180dc4f527efea2e43c134bc9f09df64592013cca075ab6ada07",
-      "tags": [
-        "south-park",
-        "french",
-        "comedy",
-        "tv"
-      ],
-      "preview_sounds": [
-        "sounds/howdy.mp3",
-        "sounds/respectemonautorite.mp3",
-        "sounds/ilsonttue.mp3"
-      ],
-      "added": "2026-02-18",
-      "updated": "2026-02-18"
-    },
-    {
-      "name": "speaki",
-      "display_name": "Petite Speaki",
-      "version": "1.0.0",
-      "description": "Petite Speaki voice pack from Trickcal Chibi Go — adorable Korean character sounds for your coding sessions",
-      "author": {
-        "name": "cjna",
-        "github": "CJNA"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "ko",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 13,
-      "total_size_bytes": 1104000,
-      "source_repo": "CJNA/peon-ping-speaki",
-      "source_ref": "v1.0.0",
-      "source_path": "speaki",
-      "manifest_sha256": "e7d1a1cbd02e04143e8f0029863b67caaf074d86f7da42b9273846773f2d4822",
-      "tags": [
-        "gaming",
-        "trickcal",
-        "chibi",
-        "korean",
-        "kawaii"
-      ],
-      "preview_sounds": [
-        {
-          "file": "sounds/session_start/speaki_hello.mp3",
-          "label": "Speaki says hello!"
-        },
-        {
-          "file": "sounds/task_acknowledge/hai.mp3",
-          "label": "Hai! Got it!"
-        }
-      ],
-      "added": "2026-02-17",
-      "updated": "2026-02-17"
-    },
-    {
-      "name": "st_worf",
-      "display_name": "Worf (Star Trek)",
-      "version": "1.0.2",
-      "description": "Worf (Star Trek) sound pack from Star Trek",
-      "author": {
-        "name": "OmegaZero",
-        "github": "OmegaZero"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "MIT",
-      "sound_count": 12,
-      "total_size_bytes": 458221,
-      "source_repo": "OmegaZero/openpeon-worf",
-      "source_ref": "v1.0.2",
-      "source_path": ".",
-      "manifest_sha256": "3c521f4b0e6f9c70e05366ddf9e2c91c1e9f01e3aea0e15978904fceb218b164",
-      "tags": [
-        "television",
-        "star-trek"
-      ],
-      "preview_sounds": [
-        "HailingOpen.wav",
-        "WheresCaptain.wav"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "starrail-kafka-peon-pack",
-      "display_name": "崩坏星穹铁道-卡芙卡语音包",
-      "version": "1.0.1",
-      "description": "崩坏星穹铁道-卡芙卡语音包",
-      "author": {
-        "name": "0w0miki",
-        "github": "0w0miki"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "session.end",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "zh",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 22,
-      "total_size_bytes": 7709704,
-      "source_repo": "0w0miki/starrail-Kafka-peon-pack",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "0bac778f75f0443251f717341116b3edea5ee69aaa7de42df919706c4f7a6ce8",
-      "tags": [
-        "gaming",
-        "starrail"
-      ],
-      "preview_sounds": [
-        "hi.wav",
-        "time-end.wav"
-      ],
-      "added": "2026-02-23",
-      "updated": "2026-02-23"
-    },
-    {
-      "name": "starship_rasczak",
-      "display_name": "Lt. Rasczak",
-      "version": "1.0.0",
-      "description": "Grizzled teacher-turned-warrior tough love.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 10,
-      "total_size_bytes": 423370,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "starship_rasczak",
-      "manifest_sha256": "d0bd5e48ae57656f527117eac36c1a2387bc8555ba7617964dcd14f791b3250f",
-      "tags": [
-        "movie-quotes",
-        "starship-troopers",
-        "sci-fi",
-        "action",
-        "michael-ironside",
-        "rasczak",
-        "military"
-      ],
-      "preview_sounds": [
-        "civilian_vs_citizen.mp3",
-        "come_on_you_apes.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "starship_rico",
-      "display_name": "Johnny Rico",
-      "version": "1.0.0",
-      "description": "Gung-ho military propaganda energy for your code.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 17,
-      "total_size_bytes": 461806,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "starship_rico",
-      "manifest_sha256": "29c6311f481a726b676e54933d6d363d848d1a2991e45f73524e1c1e0cc11ca2",
-      "tags": [
-        "movie-quotes",
-        "starship-troopers",
-        "sci-fi",
-        "action",
-        "casper-van-dien",
-        "johnny-rico",
-        "military"
-      ],
-      "preview_sounds": [
-        "buenos_aires_kill_em_all.mp3",
-        "for_all_you_new_people.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "stronghold-abbot",
-      "display_name": "The Abbot (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Abbot voice lines from Stronghold Crusader — scheming monastery lord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 14,
-      "total_size_bytes": 632044,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-abbot",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "a1edd8950bfac88b4af48153d99e547c62d559e2d90f1500f9177092329d3138",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "ab_add_player_01.wav",
-        "ab_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-caliph",
-      "display_name": "The Caliph (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Caliph voice lines from Stronghold Crusader — fierce desert warlord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 573128,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-caliph",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "66a44434883063793689cb4fb0cb077350e3ff46bd548f0ac36aae000aba7bfb",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "ca_add_player_01.wav",
-        "ca_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-emir",
-      "display_name": "The Emir (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Emir voice lines from Stronghold Crusader — cautious Arabian ally",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 592932,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-emir",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "9f1cda7e93ed2c66cf843a74f0e611fc91a50e1f4602d5e53c78ee4214eb9874",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "em_add_player_01.wav",
-        "em_vict_02.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-frederick",
-      "display_name": "Emperor Frederick (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "Emperor Frederick voice lines from Stronghold Crusader — imperial European lord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 691176,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-frederick",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "e4d338048466188e71e9e365f7a68f7043815cc428d73da934493230e50a3c27",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "fr_add_player_01.wav",
-        "fr_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-marshal",
-      "display_name": "The Marshal (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Marshal voice lines from Stronghold Crusader — gruff military commander",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 559604,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-marshal",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "bae00c488e968d178e9a3bf3fcbd16024a3b38901e4eb46109f6387692afe0d1",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "ma_add_player_01.wav",
-        "ma_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-nizar",
-      "display_name": "Nizar (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "Nizar voice lines from Stronghold Crusader — mysterious assassin lord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 526252,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-nizar",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "9afc56969581fe2594d0d97ca174f191c29448c8f3e87ad431abc4d8c28e395e",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "ni_add_player_01.wav",
-        "ni_vict_04.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-philip",
-      "display_name": "King Philip (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "King Philip voice lines from Stronghold Crusader — vain French king",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 730976,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-philip",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "fc5b132916fbc5281c0691f29fd10be37dd528f2efe409e59d9592b90562f886",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "ph_add_player_01.wav",
-        "ph_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-pig",
-      "display_name": "The Pig (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Pig voice lines from Stronghold Crusader — brutal villain lord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 974852,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-pig",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "93b46e16a3d80d5bc69a23fc61d8d89e8807f9856c4212a7fc7fb3c604586bf7",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "pg_add_player.wav",
-        "pg_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-rat",
-      "display_name": "The Rat (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Rat voice lines from Stronghold Crusader — scheming cowardly villain",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 1229628,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-rat",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "dbf0b6650707af881fe1c852fe2e89ce23c4630035c6fb2086f7f6ef15b61952",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "rt_add_player.wav",
-        "rt_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-richard",
-      "display_name": "Richard the Lionheart (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "Richard the Lionheart voice lines from Stronghold Crusader — noble crusader king",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 17,
-      "total_size_bytes": 632016,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-richard",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "eb6841797c1f05eaaba4e8b38d7306de416f6b41da84f3e9ba9e9ff474073710",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "ri_add_player_01.wav",
-        "ri_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-saladin",
-      "display_name": "Saladin (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "Saladin voice lines from Stronghold Crusader — honourable opposing sultan",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 695456,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-saladin",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "886a2d121f83cddd6165f2774166fde260d8f5fe988f8ee7c890655d5548b453",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "sa_add_player_01.wav",
-        "sa_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-sheriff",
-      "display_name": "The Sheriff (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Sheriff voice lines from Stronghold Crusader — greedy villain lord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 17,
-      "total_size_bytes": 681348,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-sheriff",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "3eed9c2db8ee4dced7471c237b15ff45d03457e1b5f5b9ddff263a286f093fa2",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "sh_add_player_01.wav",
-        "sh_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-snake",
-      "display_name": "The Snake (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Snake voice lines from Stronghold Crusader — sly manipulative villain",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 810120,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-snake",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "835241e341582962a711e6b43f38c62a7ef888f1d05c38383f33de9c92105258",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "sn_add_player.wav",
-        "sn_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-sultan",
-      "display_name": "The Sultan (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Sultan voice lines from Stronghold Crusader — poetic Arabian ally",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 741172,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-sultan",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "3d1d674ff86c786b7438dfe4f78ba25d576ac553ae423389bc9537580ec29612",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "su_add_player_01.wav",
-        "su_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-wazir",
-      "display_name": "The Wazir (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Wazir voice lines from Stronghold Crusader — aggressive desert ally",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 16,
-      "total_size_bytes": 614516,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-wazir",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "afca00bc76509e5bfa3a22438462bb6c382ff188e9a4c2424feedcf4fcd556db",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "wa_add_player_01.wav",
-        "wa_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "stronghold-wolf",
-      "display_name": "The Wolf (Stronghold Crusader)",
-      "version": "1.1.0",
-      "description": "The Wolf voice lines from Stronghold Crusader — ruthless villain lord",
-      "author": {
-        "name": "Marko Jevic",
-        "github": "koyev"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 694048,
-      "source_repo": "openpeon-stronghold/openpeon-stronghold-wolf",
-      "source_ref": "v1.1.0",
-      "source_path": ".",
-      "manifest_sha256": "bdd7d88c4dbdb2d646de21fff3b9fb228a5a6abcc2a61bee9b2e48a72bb3c722",
-      "tags": [
-        "gaming",
-        "stronghold",
-        "rts",
-        "firefly"
-      ],
-      "preview_sounds": [
-        "wf_add_player.wav",
-        "wf_vict_01.wav"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "super_troopers",
-      "display_name": "Super Troopers",
-      "version": "1.0.0",
-      "description": "Vermont highway patrol chaos.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 14,
-      "total_size_bytes": 615432,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "super_troopers",
-      "manifest_sha256": "0315d8ad7af938867770fd2f8579b222a0fe3503420c700e75c9ed9711e611b6",
-      "tags": [
-        "movie-quotes",
-        "super-troopers",
-        "comedy",
-        "broken-lizard",
-        "meow",
-        "highway-patrol"
-      ],
-      "preview_sounds": [
-        "chicken_fucker.mp3",
-        "desperation_stinky_cologne.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "super_troopers_farva",
-      "display_name": "Farva",
-      "version": "1.0.0",
-      "description": "The coworker nobody asked for.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 8,
-      "total_size_bytes": 363768,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "super_troopers_farva",
-      "manifest_sha256": "406bc52767dc60e2e685dec9798e4409ba8ff0b28bd90faa7de9dac8aa4e66bc",
-      "tags": [
-        "movie-quotes",
-        "super-troopers",
-        "comedy",
-        "broken-lizard",
-        "kevin-heffernan",
-        "farva",
-        "liter-of-cola"
-      ],
-      "preview_sounds": [
-        "car_ramrod.mp3",
-        "goddamn_liter_of_cola.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "tekken3_announcer",
-      "display_name": "Announcer (Tekken 3)",
-      "version": "1.0.0",
-      "description": "Tekken 3 announcer voice lines — Fight, K.O., You win!, and more.",
-      "author": {
-        "name": "rootbarb",
-        "github": "rootbarb"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 12,
-      "total_size_bytes": 839060,
-      "source_repo": "rootbarb/openpeon-tekken3-announcer",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "04f73b1e90ad8eda7d9f5a5e31d6306fbc12a33e2af41bd8a4c85364cc21ef91",
-      "tags": [
-        "gaming",
-        "tekken",
-        "fighting",
-        "namco"
-      ],
-      "preview_sounds": [
-        "Fight.wav"
-      ],
-      "added": "2026-02-16",
-      "updated": "2026-02-16"
-    },
-    {
-      "name": "tf2_demoman",
-      "display_name": "TF2 Demoman",
-      "version": "1.0.0",
-      "description": "TF2 Demoman sound pack from Team Fortress 2",
-      "author": {
-        "name": "Breadcat",
-        "github": "thebreadcat"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "session.end",
-        "task.acknowledge",
-        "task.progress",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 67,
-      "total_size_bytes": 2920947,
-      "source_repo": "thebreadcat/openpeon-tf2-demoman",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "5fe0b7ea4e1b0f4e6486403400b714f7d186a456e62ff210691626ed33f1a1f0",
-      "tags": [
-        "gaming",
-        "tf2",
-        "valve",
-        "fps"
-      ],
-      "preview_sounds": [
-        "demoman_battlecry01.mp3",
-        "demoman_goodjob01.mp3",
-        "demoman_autoonfire01.mp3"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "tf2_engineer",
-      "display_name": "TF2 Engineer",
-      "version": "1.0.0",
-      "description": "TF2 Engineer sound pack from Team Fortress 2",
-      "author": {
-        "name": "Arie",
-        "github": "Arie"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 51,
-      "total_size_bytes": 1381445,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "tf2_engineer",
-      "manifest_sha256": "69f13fbf23b45ea515a90f032ae5ee2a1b05b0490d546acbbd2d8c0508cade35",
-      "tags": [
-        "gaming",
-        "tf2",
-        "valve",
-        "fps"
-      ],
-      "preview_sounds": [
-        "Engineer_battlecry01.mp3",
-        "Eng_quest_complete_easy_01.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "tf2_heavy",
-      "display_name": "TF2 Heavy",
-      "version": "1.0.0",
-      "description": "TF2 Heavy sound pack from Team Fortress 2",
-      "author": {
-        "name": "Breadcat",
-        "github": "thebreadcat"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "session.end",
-        "task.acknowledge",
-        "task.progress",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 113,
-      "total_size_bytes": 5222535,
-      "source_repo": "thebreadcat/tf2-heavy-pack",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "3bf5c407fa3bd703762d4de2e9ab6eb6d92cf8283d69e6b6cbcdfdc9a8cc6c4c",
-      "tags": [
-        "gaming",
-        "tf2",
-        "valve",
-        "fps",
-        "heavy"
-      ],
-      "preview_sounds": [
-        "heavy_go01.mp3",
-        "heavy_thanks01.mp3",
-        "heavy_goodjob02.mp3",
-        "heavy_battlecry03.mp3"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "tf2_pyro",
-      "display_name": "TF2 Pyro",
-      "version": "1.0.1",
-      "description": "TF2 Pyro sound pack from Team Fortress 2",
-      "author": {
-        "name": "Breadcat",
-        "github": "thebreadcat"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "session.end",
-        "task.acknowledge",
-        "task.progress",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 27,
-      "total_size_bytes": 5222535,
-      "source_repo": "thebreadcat/tf2-pyro-pack",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "b3ec6b5fd7b309b065fe330195d75d7d64e33790a6f1a05e36392c90265977d3",
-      "tags": [
-        "gaming",
-        "tf2",
-        "valve",
-        "fps",
-        "heavy"
-      ],
-      "preview_sounds": [
-        "pyro_battlecry01.mp3",
-        "pyro_thanks01.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "tf2_sniper",
-      "display_name": "TF2 Sniper",
-      "version": "1.0.0",
-      "description": "TF2 Sniper sound pack from Team Fortress 2",
-      "author": {
-        "name": "Breadcat",
-        "github": "thebreadcat"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "session.end",
-        "task.acknowledge",
-        "task.progress",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 56,
-      "total_size_bytes": 2920947,
-      "source_repo": "thebreadcat/tf2-sniper-pack",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "b7139a7c340f5dd9eafe08656989fe6539e961fee190c1fac82bf1e4321d9104",
-      "tags": [
-        "gaming",
-        "tf2",
-        "valve",
-        "fps"
-      ],
-      "preview_sounds": [
-        "sniper_battlecry03.mp3",
-        "sniper_cheers05.mp3",
-        "sniper_jaratetoss01.mp3"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "tf2_spy",
-      "display_name": "TF2 Spy",
-      "version": "1.0.0",
-      "description": "TF2 Spy sound pack from Team Fortress 2",
-      "author": {
-        "name": "Breadcat",
-        "github": "thebreadcat"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 37,
-      "total_size_bytes": 1381445,
-      "source_repo": "thebreadcat/openpeon-tf2-spy",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "a0d2c3ef0251197eba1feb5ea417e9dd381d7010871f274f9cbe4f01a81e59d0",
-      "tags": [
-        "gaming",
-        "tf2",
-        "valve",
-        "fps"
-      ],
-      "preview_sounds": [
-        "gentlemen.mp3",
-        "cheers-doctor.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "the-big-lebowski",
-      "display_name": "The Big Lebowski",
-      "version": "1.0.1",
-      "description": "The Dude abides. Iconic lines from The Big Lebowski.",
-      "author": {
-        "name": "Taylan Aydinli",
-        "github": "taylan"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "session.end",
-        "task.progress",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 160,
-      "total_size_bytes": 6095239,
-      "source_repo": "taylan/openpeon-the-big-lebowski",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "ee46fe2e0c838f65737e306d51c1f2e37ba2f3177e543c4540e029f1a0292f2d",
-      "tags": [
-        "movie",
-        "comedy",
-        "coen-brothers"
-      ],
-      "preview_sounds": [
-        "001-the-dude-abides.mp3",
-        "103-shut-the-fuck-up-donny.mp3"
-      ],
-      "added": "2026-03-01",
-      "updated": "2026-03-01"
-    },
-    {
-      "name": "totally-spies-fr",
-      "display_name": "Totally spies (FR)",
-      "version": "1.0.1",
-      "description": "Best of Totally Spies (FR): Jerry, Clover, Sam & Alex <3",
-      "author": {
-        "name": "Capucine R.",
-        "github": "capucineROHART"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-ND",
-      "sound_count": 17,
-      "total_size_bytes": 1479709,
-      "source_repo": "capucineROHART/openpeon-totally-spies-fr",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "ea6d4f9e0dd5e250bd7ea4968919600bd84feb4de3d5b1e550045e86b30eaf79",
-      "tags": [
-        "badies",
-        "spies"
-      ],
-      "preview_sounds": [
-        "compowder.mp3",
-        "bonjour_mesdemoiselles.mp3"
-      ],
-      "added": "2026-02-18",
-      "updated": "2026-02-18"
-    },
-    {
-      "name": "warcraft-peon",
-      "display_name": "Warcraft 3 Peon",
-      "version": "1.0.0",
-      "description": "Warcraft 3 Peon sounds for OpenPeon",
-      "author": {
-        "name": "rocktane",
-        "github": "rocktane"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "task.complete"
-      ],
-      "language": "fr",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 1,
-      "total_size_bytes": 13431,
-      "source_repo": "rocktane/openpeon-warcraft-peon",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "e3bd17476b26de2cf51580991cec5ceb2c8c6db78e8f53e3b43f9ab18baaace7",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "task-complete.mp3"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "warcraft3-czech",
-      "display_name": "Warcraft III - Czech Peasant & Knight",
-      "version": "1.0.0",
-      "description": "Warcraft III Peasant & Knight sound alerts for Claude Code. Czech dubbed voices from the iconic RTS. Huráááá do práce!",
-      "author": {
-        "name": "Tomas Pflanzer",
-        "github": "gizmax"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.acknowledge",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "cs",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 5,
-      "total_size_bytes": 350324,
-      "source_repo": "gizmax/claude-code-wc3-sounds",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "5cce63a853aee7832224c8f33bb184e6cde937d4074cbac158431f55f94a1433",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts",
-        "czech",
-        "nostalgia"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.wav",
-        "PeasantBuildingComplete1.wav"
-      ],
-      "added": "2026-02-18",
-      "updated": "2026-02-18"
-    },
-    {
-      "name": "warcraft3-mix",
-      "display_name": "Warcraft III Mix CZ",
-      "version": "1.0.0",
-      "description": "Mix ikonických českých hlášek z Warcraft III od různých jednotek a hrdinů.",
-      "author": {
-        "name": "SgtMarmite",
-        "github": "SgtMarmite"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "cs",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 225,
-      "total_size_bytes": 17949988,
-      "source_repo": "SgtMarmite/peonping-warcraft3-mix",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "9f2ab8a55ee27ea1bef2c897242c4252133470c87a7cb96bd1e05c62530a7f3a",
-      "tags": [
-        "warcraft",
-        "warcraft3",
-        "blizzard",
-        "mix",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeonWhat4.wav",
-        "ArthasYes1.wav"
-      ],
-      "added": "2026-02-24",
-      "updated": "2026-02-24"
-    },
-    {
-      "name": "wc2_human_ships",
-      "display_name": "WC2 Human Ships",
-      "version": "1.0.0",
-      "description": "Human naval unit voice lines from Warcraft II: Tides of Darkness",
-      "author": {
-        "name": "dmnd",
-        "github": "dmnd"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 22,
-      "total_size_bytes": 168954,
-      "source_repo": "dmnd/peonping-wc2_human_ships",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "a6c7d3f3ee21ae56fbc19a88d0ddf7e9a4b232e71eb30b529e0b621228dc1766",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "human1.wav",
-        "acknowledge1.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "wc2_peasant",
-      "display_name": "WC2 Peasant",
-      "version": "1.0.0",
-      "description": "WC2 Peasant sound pack from Warcraft II",
-      "author": {
-        "name": "sebbeth",
-        "github": "sebbeth"
-      },
-      "trust_tier": "official",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 21,
-      "total_size_bytes": 167005,
-      "source_repo": "PeonPing/og-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "wc2_peasant",
-      "manifest_sha256": "dcaea0f2fbbd8b5da5717c86604cf3dc401dc35b09fdfe512cf9f19279d32d06",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ReadyToServe.mp3",
-        "JobsDone.mp3"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "wc2_peasant_pt-br",
-      "display_name": "WC2 Human Peasant (PT-BR)",
-      "version": "1.1.1",
-      "description": "Human Peasant voice lines from WarCraft II dubbed in Brazilian Portuguese",
-      "author": {
-        "name": "Lucas Oliveira",
-        "github": "lucaspwo"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "pt-BR",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 18,
-      "total_size_bytes": 206180,
-      "source_repo": "lucaspwo/openpeon-wc2-peasant-pt-br",
-      "source_ref": "v1.1.1",
-      "source_path": ".",
-      "manifest_sha256": "52bf0298116a357a67a0d7aeb522dd1571366fab8990a1fe97b39453b74b4d18",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ReadyToServe.mp3",
-        "WorkComplete.mp3"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "wc2_sapper",
-      "display_name": "WC2 Goblin Sappers",
-      "version": "1.0.0",
-      "description": "The shrill sounds of goblin sappers from Warcraft II",
-      "author": {
-        "name": "anwilk",
-        "github": "anwilk"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 12,
-      "total_size_bytes": 300000,
-      "source_repo": "anwilk/openpeon-wc2_sapper",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "0c4f32f3f7fb771e087bba50ad60d0f6ba2c2d4219e52b7e7664ba8b998f9434",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "ready.wav",
-        "beautiful.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "wc3_corrupted_arthas",
-      "display_name": "Corrupted Arthas (WarCraft 3)",
-      "version": "1.0.3",
-      "description": "Corrupted Arthas (WarCraft 3) sound pack from WarCraft 3",
-      "author": {
-        "name": "OmegaZero",
-        "github": "OmegaZero"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "MIT",
-      "sound_count": 15,
-      "total_size_bytes": 3610314,
-      "source_repo": "OmegaZero/openpeon-corrupted-arthas",
-      "source_ref": "v1.0.3",
-      "source_path": ".",
-      "manifest_sha256": "31ba5d39f59d3cb63921b2f6927b5e58953ee51b6917d3eec08e51398383476e",
-      "tags": [
-        "gaming",
-        "warcraft3",
-        "rts"
-      ],
-      "preview_sounds": [
-        "SpeakFool.wav",
-        "WhatIsItNow.wav"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "wc3_jaina",
-      "display_name": "Jaina Proudmore (WarCraft 3)",
-      "version": "1.0.0",
-      "description": "Jaina Proudmore (WarCraft 3) sound pack from WarCraft 3",
-      "author": {
-        "name": "OmegaZero",
-        "github": "OmegaZero"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "MIT",
-      "sound_count": 13,
-      "total_size_bytes": 1052426,
-      "source_repo": "OmegaZero/openpeon-jaina",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "cde6367b42906933d72ecdae706ab9217ac9f382c407cb41ef62b3eb89598b47",
-      "tags": [
-        "gaming",
-        "warcraft3",
-        "rts"
-      ],
-      "preview_sounds": [
-        "JainaCanHelp.wav",
-        "JainaWhatsThePlan.wav"
-      ],
-      "added": "2026-02-12",
-      "updated": "2026-02-12"
-    },
-    {
-      "name": "wc3_peasant_pt-br",
-      "display_name": "WC3 Human Peasant (PT-BR)",
-      "version": "1.0.1",
-      "description": "Human Peasant voice lines from WarCraft III dubbed in Brazilian Portuguese",
-      "author": {
-        "name": "Lucas Oliveira",
-        "github": "lucaspwo"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "pt-BR",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 21,
-      "total_size_bytes": 364120,
-      "source_repo": "lucaspwo/open-peon-war3PT_BR",
-      "source_ref": "v1.0.1",
-      "source_path": ".",
-      "manifest_sha256": "fbe43123e4c5a1e730c2245799b9942a347678e025341d7f955e92ac101a12e6",
-      "tags": [
-        "gaming",
-        "warcraft",
-        "blizzard",
-        "rts"
-      ],
-      "preview_sounds": [
-        "PeasantReady1.mp3",
-        "PeasantBuildingComplete1.mp3"
-      ],
-      "added": "2026-02-14",
-      "updated": "2026-02-14"
-    },
-    {
-      "name": "wolf-et-pack",
-      "display_name": "Wolf:ET Pack",
-      "version": "1.0.0",
-      "description": "Wolfenstein: Enemy Territory HQ command voiceovers — Allied and Axis variants",
-      "author": {
-        "name": "Graham Mackie",
-        "github": "gmackie"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 186,
-      "total_size_bytes": 22234324,
-      "source_repo": "gmackie/wolf-et-pack",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "23e34efeaf2238d3aface0c2a4c85f6af6440fac57fe42375919feda5c0f4ba4",
-      "tags": [
-        "gaming",
-        "fps",
-        "wolfenstein",
-        "splash-damage"
-      ],
-      "preview_sounds": [
-        "sounds/ack/allies/hq_dynplanted_a.wav",
-        "sounds/complete/allies/hq_objdest.wav"
-      ],
-      "added": "2026-02-13",
-      "updated": "2026-02-13"
-    },
-    {
-      "name": "worms-armageddon",
-      "display_name": "Worms Armageddon",
-      "version": "1.0.0",
-      "description": "Classic voice samples from Worms Armageddon featuring the iconic British worm taunts and exclamations",
-      "author": {
-        "name": "Mina Tawadrous",
-        "github": "mtmac17"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.complete",
-        "task.error",
-        "input.required"
-      ],
-      "language": "en",
-      "license": "MIT",
-      "sound_count": 14,
-      "total_size_bytes": 179678,
-      "source_repo": "mtmac17/openpeon-worms-armageddon",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "d596c5402477d614746f7e1b4c9f904dabfbe786fdf5ebab22e3909ac2e12ef5",
-      "tags": [
-        "gaming",
-        "strategy",
-        "worms",
-        "team17",
-        "comedy"
-      ],
-      "preview_sounds": [
-        "sounds/greeting-hello.wav",
-        "sounds/done-excellent.wav"
-      ],
-      "added": "2026-02-19",
-      "updated": "2026-02-19"
-    },
-    {
-      "name": "zelda-a-link-to-the-past",
-      "display_name": "Zelda: A Link to the Past Sound Pack",
-      "version": "1.0.0",
-      "description": "Selected sound effects, jingles and music snippets from The Legend of Zelda: A Link to the Past",
-      "author": {
-        "name": "Henning Rokling",
-        "github": "hrokling"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "input.required",
-        "resource.limit",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "CC-BY-NC-4.0",
-      "sound_count": 24,
-      "total_size_bytes": 24227328,
-      "source_repo": "hrokling/zelda-a-link-to-the-past",
-      "source_ref": "v1.0.0",
-      "source_path": ".",
-      "manifest_sha256": "48387e8e22951872eb81249a73e1a259161ce2b355e979c0fb79d9f7fc7caa4c",
-      "tags": [
-        "zelda",
-        "nintendo",
-        "retro",
-        "game"
-      ],
-      "preview_sounds": [
-        "sounds/secret.wav",
-        "sounds/fairy.wav"
-      ],
-      "added": "2026-02-20",
-      "updated": "2026-02-20"
-    },
-    {
-      "name": "zoolander_derek",
-      "display_name": "Derek Zoolander",
-      "version": "1.0.0",
-      "description": "Really, really, ridiculously good looking notifications.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 15,
-      "total_size_bytes": 439011,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "zoolander_derek",
-      "manifest_sha256": "5e87d587f5c921ac4923978627de599d52bcfa6bf7cbf9c92173c38e0249b280",
-      "tags": [
-        "movie-quotes",
-        "zoolander",
-        "comedy",
-        "ben-stiller",
-        "derek-zoolander",
-        "blue-steel",
-        "male-models"
-      ],
-      "preview_sounds": [
-        "but_why_male_models.mp3",
-        "but_why_male_models_1.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    },
-    {
-      "name": "zoolander_hansel",
-      "display_name": "Hansel",
-      "version": "1.0.0",
-      "description": "So hot right now.",
-      "author": {
-        "name": "Willow Billock",
-        "github": "MattBillock"
-      },
-      "trust_tier": "community",
-      "categories": [
-        "input.required",
-        "resource.limit",
-        "session.start",
-        "task.acknowledge",
-        "task.complete",
-        "task.error",
-        "user.spam"
-      ],
-      "language": "en",
-      "license": "fair-use",
-      "sound_count": 13,
-      "total_size_bytes": 453569,
-      "source_repo": "MattBillock/openpeon-movie-packs",
-      "source_ref": "v1.0.0",
-      "source_path": "zoolander_hansel",
-      "manifest_sha256": "87f049012873b6637ffa8907dac80c36695504ab5a06f9143cc4b6d38ab37c24",
-      "tags": [
-        "movie-quotes",
-        "zoolander",
-        "comedy",
-        "owen-wilson",
-        "hansel",
-        "so-hot-right-now"
-      ],
-      "preview_sounds": [
-        "excuse_me_bro.mp3",
-        "gasoline_fight_accident.mp3"
-      ],
-      "added": "2026-02-25",
-      "updated": "2026-02-25"
-    }
-  ],
-  "total_packs": 86
+    ],
+    "total_packs": 159
 }


### PR DESCRIPTION
## Summary

Updates all 16 Stronghold Crusader lord packs:

- **Rename pack names** from `stronghold-<lord>` to short names (`rat`, `wolf`, etc.) — install command is now `peon packs install rat`
- **Update source repos** from `openpeon-stronghold/openpeon-stronghold-<lord>` to `openpeon-stronghold/<lord>` (repos were renamed)
- **Bump to v1.2.0** — sounds converted from WAV to MP3
- **Updated manifest SHA256** for new MP3-based manifests
- **Updated preview_sounds** file extensions to `.mp3`
- **Refreshed sound_count and total_size_bytes**

## Lords updated

abbot, caliph, emir, emperor-frederick, marshal, nizar, king-philip, pig, rat, king-richard, saladin, sheriff, snake, sultan, wazir, wolf