### PR TITLE
Fix audio spot-check for packs with sound subdirectories

### DIFF
--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -268,7 +268,7 @@ jobs:
                   for sound in cat_data.get('sounds', []):
                       f = sound.get('file', '')
                       if f:
-                          sound_files.add(os.path.basename(f))
+                          sound_files.add(f)
 
               if not sound_files:
                   errors.append(f"{name}: no sound files referenced in manifest")
@@ -283,7 +283,7 @@ jobs:
 
               # 5. Spot-check up to 3 sound files exist and are audio
               for sfile in sorted(sound_files)[:3]:
-                  sound_url = f"{base}/sounds/{sfile}"
+                  sound_url = f"{base}/{sfile}"
                   try:
                       req = urllib.request.urlopen(sound_url, timeout=15)
                       data = req.read(256)


### PR DESCRIPTION
## Summary
- The audio spot-check in `validate-index.yml` uses `os.path.basename()` on manifest file paths, stripping any subdirectory structure under `sounds/`
- It then constructs URLs as `{base}/sounds/{basename}`, which 404s for packs that organize sounds into category subdirectories (e.g. `sounds/session.start/foo.mp3`)
- Fix: use the full manifest `file` path (which already includes the `sounds/` prefix) and construct URLs as `{base}/{file_path}`

This is backwards-compatible — packs with flat `sounds/` directories still work since their paths are already `sounds/foo.wav`.

Discovered via #131 which uses category subdirectories under `sounds/`.