### PR TITLE
Add jarvis-mk2 sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -5,7 +5,7 @@
       "name": "abbot",
       "display_name": "The Abbot (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Abbot voice lines from Stronghold Crusader \u2014 scheming monastery lord",
+      "description": "The Abbot voice lines from Stronghold Crusader — scheming monastery lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -83,7 +83,7 @@
     },
     {
       "name": "acolyte_es",
-      "display_name": "Ac\u00f3lito Muertos Vivientes Warcraft III (ES)",
+      "display_name": "Acólito Muertos Vivientes Warcraft III (ES)",
       "version": "1.0.2",
       "description": "Spanish Undead Acolyte sound pack from Warcraft III",
       "author": {
@@ -163,9 +163,9 @@
     },
     {
       "name": "ae_qianyu",
-      "display_name": "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730 \u9648\u5343\u8bed",
+      "display_name": "明日方舟:终末地 陈千语",
       "version": "1.0.4",
-      "description": "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730 \u9648\u5343\u8bed \u8bed\u97f3\u5305",
+      "description": "明日方舟:终末地 陈千语 语音包",
       "author": {
         "name": "LiRiu",
         "github": "LiRiu"
@@ -189,7 +189,7 @@
       "manifest_sha256": "50fd5866b2f025deba93723ceae9aa77ef88302efa7915711d881222c391d67b",
       "tags": [
         "gaming",
-        "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730",
+        "明日方舟:终末地",
         "arknights:endfield"
       ],
       "preview_sounds": [
@@ -690,9 +690,9 @@
     },
     {
       "name": "arthas_ru",
-      "display_name": "\u0410\u0440\u0442\u0430\u0441 \u0420\u044b\u0446\u0430\u0440\u044c \u0421\u043c\u0435\u0440\u0442\u0438 (Russian)",
+      "display_name": "Артас Рыцарь Смерти (Russian)",
       "version": "1.0.0",
-      "description": "WC3 Death Knight Arthas \u2014 all 20 Russian voice lines mapped to CESP categories",
+      "description": "WC3 Death Knight Arthas — all 20 Russian voice lines mapped to CESP categories",
       "author": {
         "name": "samokay",
         "github": "samokay"
@@ -903,7 +903,7 @@
       "name": "caliph",
       "display_name": "The Caliph (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Caliph voice lines from Stronghold Crusader \u2014 diplomatic desert lord",
+      "description": "The Caliph voice lines from Stronghold Crusader — diplomatic desert lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -1103,7 +1103,7 @@
       "name": "charlie_sheen",
       "display_name": "Charlie Sheen",
       "version": "1.0.0",
-      "description": "Charlie Sheen's iconic interview quotes \u2014 Winning, tiger blood, and more.",
+      "description": "Charlie Sheen's iconic interview quotes — Winning, tiger blood, and more.",
       "author": {
         "name": "rootbarb",
         "github": "rootbarb"
@@ -1543,7 +1543,7 @@
       "name": "dota2_ember_spirit",
       "display_name": "Ember Spirit (Dota 2)",
       "version": "1.0.0",
-      "description": "Ember Spirit (Dota 2) sound pack \u2014 'Balance in all things.'",
+      "description": "Ember Spirit (Dota 2) sound pack — 'Balance in all things.'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -1583,7 +1583,7 @@
       "name": "dota2_invoker",
       "display_name": "Invoker (Dota 2)",
       "version": "1.0.0",
-      "description": "Invoker (Dota 2) sound pack \u2014 'So begins a new age of knowledge.'",
+      "description": "Invoker (Dota 2) sound pack — 'So begins a new age of knowledge.'",
       "author": {
         "name": "bwarren2",
         "github": "bwarren2"
@@ -1623,7 +1623,7 @@
       "name": "dota2_phantom_lancer",
       "display_name": "Phantom Lancer (Dota 2)",
       "version": "1.0.0",
-      "description": "Phantom Lancer (Dota 2) sound pack \u2014 'From one: an army.'",
+      "description": "Phantom Lancer (Dota 2) sound pack — 'From one: an army.'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -1663,7 +1663,7 @@
       "name": "dota2_witch_doctor",
       "display_name": "Witch Doctor (Dota 2)",
       "version": "1.0.0",
-      "description": "Witch Doctor (Dota 2) sound pack \u2014 'De Doctor is in!'",
+      "description": "Witch Doctor (Dota 2) sound pack — 'De Doctor is in!'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -1703,7 +1703,7 @@
       "name": "dota2_zeus",
       "display_name": "Zeus (Dota 2)",
       "version": "1.0.0",
-      "description": "Zeus (Dota 2) sound pack \u2014 'Your god has arrived.'",
+      "description": "Zeus (Dota 2) sound pack — 'Your god has arrived.'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -1821,7 +1821,7 @@
       "name": "emir",
       "display_name": "The Emir (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Emir voice lines from Stronghold Crusader \u2014 fierce Arabian lord",
+      "description": "The Emir voice lines from Stronghold Crusader — fierce Arabian lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -1901,7 +1901,7 @@
       "name": "frederick",
       "display_name": "Emperor Frederick (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "Emperor Frederick voice lines from Stronghold Crusader \u2014 noble crusader emperor",
+      "description": "Emperor Frederick voice lines from Stronghold Crusader — noble crusader emperor",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -2176,6 +2176,49 @@
       ],
       "added": "2026-02-25",
       "updated": "2026-02-25"
+    },
+    {
+      "name": "jarvis-mk2",
+      "display_name": "J.A.R.V.I.S.",
+      "version": "1.0.0",
+      "description": "Paul Bettany-inspired AI butler. Calm, dry, never panicked. 45 lines of composure under absurdity.",
+      "author": {
+        "name": "FlynnCruse",
+        "github": "FlynnCruse"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 45,
+      "total_size_bytes": 1944218,
+      "source_repo": "FlynnCruse/openpeon-jarvis",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "ffdec6c408b07b89ca3acd63275d5911fca45b1e6ee187f587101e968f9e9e45",
+      "tags": [
+        "movie",
+        "marvel",
+        "mcu",
+        "ai",
+        "british",
+        "tts",
+        "elevenlabs"
+      ],
+      "preview_sounds": [
+        "sounds/session_start_1.mp3",
+        "sounds/complete_2.mp3"
+      ],
+      "added": "2026-03-03",
+      "updated": "2026-03-03"
     },
     {
       "name": "kaamelott",
@@ -2516,9 +2559,9 @@
       "name": "marcel",
       "display_name": "Marcel",
       "version": "1.0.0",
-      "description": "Legendary quotes of Marcel Mer\u010diak.",
+      "description": "Legendary quotes of Marcel Merčiak.",
       "author": {
-        "name": "Mari\u00e1n \u010cam\u00e1k",
+        "name": "Marián Čamák",
         "github": "mcamak"
       },
       "trust_tier": "community",
@@ -2553,7 +2596,7 @@
       "name": "marshal",
       "display_name": "The Marshal (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Marshal voice lines from Stronghold Crusader \u2014 loyal European lord",
+      "description": "The Marshal voice lines from Stronghold Crusader — loyal European lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -2591,11 +2634,11 @@
     },
     {
       "name": "milujipraci",
-      "display_name": "Miluji Pr\u00e1ci",
+      "display_name": "Miluji Práci",
       "version": "1.0.0",
-      "description": "Legendary quotes of Lubo\u0161 fixing Lakato\u0161.",
+      "description": "Legendary quotes of Luboš fixing Lakatoš.",
       "author": {
-        "name": "Franti\u0161ek Z\u00e1hora",
+        "name": "František Záhora",
         "github": "arguit"
       },
       "trust_tier": "community",
@@ -2629,7 +2672,7 @@
       "version": "1.0.1",
       "description": "Villager sound pack from Minecraft.",
       "author": {
-        "name": "Eric Ker\u00e4nen",
+        "name": "Eric Keränen",
         "github": "Mahamurahti"
       },
       "trust_tier": "community",
@@ -2815,7 +2858,7 @@
       "name": "nizar",
       "display_name": "Nizar (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "Nizar voice lines from Stronghold Crusader \u2014 cunning assassin lord",
+      "description": "Nizar voice lines from Stronghold Crusader — cunning assassin lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -3144,9 +3187,9 @@
     },
     {
       "name": "peasant_cz",
-      "display_name": "Lidsk\u00fd roln\u00edk (CZ)",
+      "display_name": "Lidský rolník (CZ)",
       "version": "1.0.0",
-      "description": "Lidsk\u00fd roln\u00edk (CZ) sound pack from Warcraft III",
+      "description": "Lidský rolník (CZ) sound pack from Warcraft III",
       "author": {
         "name": "vojtabiberle",
         "github": "vojtabiberle"
@@ -3344,9 +3387,9 @@
     },
     {
       "name": "peon_cz",
-      "display_name": "Or\u010d\u00ed pe\u00f3n (CZ)",
+      "display_name": "Orčí peón (CZ)",
       "version": "1.0.0",
-      "description": "Or\u010d\u00ed pe\u00f3n (CZ) sound pack from Warcraft III",
+      "description": "Orčí peón (CZ) sound pack from Warcraft III",
       "author": {
         "name": "vojtabiberle",
         "github": "vojtabiberle"
@@ -3586,7 +3629,7 @@
       "name": "philip",
       "display_name": "King Philip (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "King Philip voice lines from Stronghold Crusader \u2014 proud king of France",
+      "description": "King Philip voice lines from Stronghold Crusader — proud king of France",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -3626,7 +3669,7 @@
       "name": "pig",
       "display_name": "The Pig (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Pig voice lines from Stronghold Crusader \u2014 brutal villain lord",
+      "description": "The Pig voice lines from Stronghold Crusader — brutal villain lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -3749,7 +3792,7 @@
       "name": "protoss",
       "display_name": "Protoss (StarCraft)",
       "version": "1.0.0",
-      "description": "StarCraft Protoss voice lines and sound effects \u2014 en taro Adun!",
+      "description": "StarCraft Protoss voice lines and sound effects — en taro Adun!",
       "author": {
         "name": "Cody Born",
         "github": "codyborn"
@@ -4089,7 +4132,7 @@
       "name": "rat",
       "display_name": "The Rat (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Rat voice lines from Stronghold Crusader \u2014 scheming cowardly villain",
+      "description": "The Rat voice lines from Stronghold Crusader — scheming cowardly villain",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -4129,7 +4172,7 @@
       "name": "richard",
       "display_name": "King Richard (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "King Richard voice lines from Stronghold Crusader \u2014 noble English crusader king",
+      "description": "King Richard voice lines from Stronghold Crusader — noble English crusader king",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -4208,7 +4251,7 @@
       "name": "saladin",
       "display_name": "Saladin (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "Saladin voice lines from Stronghold Crusader \u2014 honourable sultan of Egypt",
+      "description": "Saladin voice lines from Stronghold Crusader — honourable sultan of Egypt",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -4674,7 +4717,7 @@
       "name": "sc_firebat",
       "display_name": "StarCraft Firebat",
       "version": "2.0.0",
-      "description": "StarCraft Firebat sound pack \u2014 17 SC1 voice lines across all 7 CESP categories, featuring 'Need a light?' and propane references",
+      "description": "StarCraft Firebat sound pack — 17 SC1 voice lines across all 7 CESP categories, featuring 'Need a light?' and propane references",
       "author": {
         "name": "kschmidtjr1",
         "github": "kschmidtjr1"
@@ -4827,7 +4870,7 @@
       "name": "sc_marine",
       "display_name": "StarCraft Marine",
       "version": "1.0.0",
-      "description": "StarCraft Marine sound pack \u2014 iconic lines including 'Rock 'n' roll!' and 'You want a piece of me, boy?'",
+      "description": "StarCraft Marine sound pack — iconic lines including 'Rock 'n' roll!' and 'You want a piece of me, boy?'",
       "author": {
         "name": "harrymunro",
         "github": "harrymunro"
@@ -4867,7 +4910,7 @@
       "name": "sc_medic",
       "display_name": "StarCraft Medic",
       "version": "2.0.0",
-      "description": "StarCraft Medic sound pack \u2014 16 SC1 voice lines across all 7 CESP categories, featuring 'He's dead, Jim' and medical humor",
+      "description": "StarCraft Medic sound pack — 16 SC1 voice lines across all 7 CESP categories, featuring 'He's dead, Jim' and medical humor",
       "author": {
         "name": "kschmidtjr1",
         "github": "kschmidtjr1"
@@ -4944,7 +4987,7 @@
       "name": "sc_scv",
       "display_name": "StarCraft SCV",
       "version": "2.0.0",
-      "description": "StarCraft SCV sound pack \u2014 expanded with 19 sounds across all 7 CESP categories",
+      "description": "StarCraft SCV sound pack — expanded with 19 sounds across all 7 CESP categories",
       "author": {
         "name": "harrymunro",
         "github": "harrymunro"
@@ -4984,7 +5027,7 @@
       "name": "sc_tank",
       "display_name": "StarCraft Siege Tank",
       "version": "2.0.0",
-      "description": "StarCraft Siege Tank sound pack \u2014 14 SC1 voice lines across all 7 CESP categories, featuring Ride of the Valkyries and 'drop the hammer'",
+      "description": "StarCraft Siege Tank sound pack — 14 SC1 voice lines across all 7 CESP categories, featuring Ride of the Valkyries and 'drop the hammer'",
       "author": {
         "name": "kschmidtjr1",
         "github": "kschmidtjr1"
@@ -5214,7 +5257,7 @@
       "name": "sheriff",
       "display_name": "The Sheriff (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Sheriff voice lines from Stronghold Crusader \u2014 greedy corrupt villain",
+      "description": "The Sheriff voice lines from Stronghold Crusader — greedy corrupt villain",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -5254,7 +5297,7 @@
       "name": "silicon_valley",
       "display_name": "Silicon Valley",
       "version": "2.2.0",
-      "description": "Quotes from Silicon Valley \u2014 Erlich, Gilfoyle, Russ Hanneman, Jian Yang. English + Russian dubbed by \u00ab\u041a\u0443\u0431\u0438\u043a \u0432 \u043a\u0443\u0431\u0438\u043a\u0435\u00bb (59 clips with swearing)",
+      "description": "Quotes from Silicon Valley — Erlich, Gilfoyle, Russ Hanneman, Jian Yang. English + Russian dubbed by «Кубик в кубике» (59 clips with swearing)",
       "author": {
         "name": "rustam",
         "github": "fortunto2"
@@ -5294,7 +5337,7 @@
       "name": "snake",
       "display_name": "The Snake (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Snake voice lines from Stronghold Crusader \u2014 treacherous villain lord",
+      "description": "The Snake voice lines from Stronghold Crusader — treacherous villain lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -5424,9 +5467,9 @@
       "name": "southpark-fr",
       "display_name": "South Park Fr",
       "version": "1.0.0",
-      "description": "Sons issus de la bo\u00eete \u00e0 South Park (VF Game One)",
+      "description": "Sons issus de la boîte à South Park (VF Game One)",
       "author": {
-        "name": "Cl\u00e9ment",
+        "name": "Clément",
         "github": "Telmalk"
       },
       "trust_tier": "community",
@@ -5467,7 +5510,7 @@
       "name": "speaki",
       "display_name": "Petite Speaki",
       "version": "1.0.0",
-      "description": "Petite Speaki voice pack from Trickcal Chibi Go \u2014 adorable Korean character sounds for your coding sessions",
+      "description": "Petite Speaki voice pack from Trickcal Chibi Go — adorable Korean character sounds for your coding sessions",
       "author": {
         "name": "cjna",
         "github": "CJNA"
@@ -5550,9 +5593,9 @@
     },
     {
       "name": "starrail-kafka-peon-pack",
-      "display_name": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
+      "display_name": "崩坏星穹铁道-卡芙卡语音包",
       "version": "1.0.1",
-      "description": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
+      "description": "崩坏星穹铁道-卡芙卡语音包",
       "author": {
         "name": "0w0miki",
         "github": "0w0miki"
@@ -5677,7 +5720,7 @@
       "name": "sultan",
       "display_name": "The Sultan (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Sultan voice lines from Stronghold Crusader \u2014 powerful desert sultan",
+      "description": "The Sultan voice lines from Stronghold Crusader — powerful desert sultan",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -5802,7 +5845,7 @@
       "name": "tekken3_announcer",
       "display_name": "Announcer (Tekken 3)",
       "version": "1.0.0",
-      "description": "Tekken 3 announcer voice lines \u2014 Fight, K.O., You win!, and more.",
+      "description": "Tekken 3 announcer voice lines — Fight, K.O., You win!, and more.",
       "author": {
         "name": "rootbarb",
         "github": "rootbarb"
@@ -6205,7 +6248,7 @@
       "name": "warcraft3-czech",
       "display_name": "Warcraft III - Czech Peasant & Knight",
       "version": "1.0.0",
-      "description": "Warcraft III Peasant & Knight sound alerts for Claude Code. Czech dubbed voices from the iconic RTS. Hur\u00e1\u00e1\u00e1\u00e1 do pr\u00e1ce!",
+      "description": "Warcraft III Peasant & Knight sound alerts for Claude Code. Czech dubbed voices from the iconic RTS. Huráááá do práce!",
       "author": {
         "name": "Tomas Pflanzer",
         "github": "gizmax"
@@ -6245,7 +6288,7 @@
       "name": "warcraft3-mix",
       "display_name": "Warcraft III Mix CZ",
       "version": "1.0.0",
-      "description": "Mix ikonick\u00fdch \u010desk\u00fdch hl\u00e1\u0161ek z Warcraft III od r\u016fzn\u00fdch jednotek a hrdin\u016f.",
+      "description": "Mix ikonických českých hlášek z Warcraft III od různých jednotek a hrdinů.",
       "author": {
         "name": "SgtMarmite",
         "github": "SgtMarmite"
@@ -6286,7 +6329,7 @@
       "name": "wazir",
       "display_name": "The Wazir (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Wazir voice lines from Stronghold Crusader \u2014 scheming Arabian lord",
+      "description": "The Wazir voice lines from Stronghold Crusader — scheming Arabian lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -6604,7 +6647,7 @@
       "name": "wolf",
       "display_name": "The Wolf (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Wolf voice lines from Stronghold Crusader \u2014 ruthless villain lord",
+      "description": "The Wolf voice lines from Stronghold Crusader — ruthless villain lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -6644,7 +6687,7 @@
       "name": "wolf-et-pack",
       "display_name": "Wolf:ET Pack",
       "version": "1.0.0",
-      "description": "Wolfenstein: Enemy Territory HQ command voiceovers \u2014 Allied and Axis variants",
+      "description": "Wolfenstein: Enemy Territory HQ command voiceovers — Allied and Axis variants",
       "author": {
         "name": "Graham Mackie",
         "github": "gmackie"


### PR DESCRIPTION
## Summary
- Adds **jarvis-mk2** — a J.A.R.V.I.S. (MCU) sound pack with 45 voice lines
- 16 canon MCU quotes (Iron Man 1-3, Avengers) + 29 original lines written in JARVIS voice
- All 7 CESP categories covered (6 core + `user.spam`)
- Voice generated via ElevenLabs custom clone (`eleven_multilingual_v2`, 44.1kHz MP3)
- Total size: 1.9 MB, all SHA256 hashes verified

## Source repo
https://github.com/FlynnCruse/openpeon-jarvis (`v1.0.0`)

## Tags
`movie`, `marvel`, `mcu`, `ai`, `british`, `tts`, `elevenlabs`