### PR TITLE
Add tropic-thunder v1.0.0

### DIFF
--- a/index.json
+++ b/index.json
@@ -6658,6 +6658,44 @@
       "updated": "2026-02-18"
     },
     {
+      "name": "tropic-thunder",
+      "display_name": "Tropic Thunder",
+      "version": "1.0.0",
+      "description": "Iconic lines from the 2008 comedy Tropic Thunder.",
+      "author": {
+        "name": "Taylan Aydinli",
+        "github": "taylan"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "session.end",
+        "task.progress",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 105,
+      "total_size_bytes": 5159419,
+      "source_repo": "taylan/openpeon-tropic-thunder",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "def523b301a8959db2c87c3b27ad502134cd08ec1016a6e160c1fb13f27b8947",
+      "tags": [
+        "comedy",
+        "movie-quotes",
+        "tropic-thunder"
+      ],
+      "preview_sounds": [],
+      "added": "2026-03-10",
+      "updated": "2026-03-10"
+    },
+    {
       "name": "warcraft-peon",
       "display_name": "Warcraft 3 Peon",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary
- Adds **tropic-thunder** v1.0.0 — 105 clips from the 2008 comedy Tropic Thunder
- 9 categories, 120 total assignments
- Source: [taylan/openpeon-tropic-thunder](https://github.com/taylan/openpeon-tropic-thunder) @ v1.0.0