### PR TITLE
Add zugzug sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -11850,7 +11850,7 @@
     {
       "name": "zugzug",
       "display_name": "Zug Zug",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "A sound pack inspired by Warcraft peon responses",
       "author": {
         "name": "dmurai",
@@ -11873,9 +11873,9 @@
       "sound_count": 14,
       "total_size_bytes": 154426,
       "source_repo": "dmurai/zugzug",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": ".",
-      "manifest_sha256": "9bae8d8cccaeddda2ec99412b949845aeb44fbffdca4c798c96dd77ccde78388",
+      "manifest_sha256": "3fd4b7c8f4d9d8b68dfd4f88b50219add75c675b5eab1a538d85275acf5ad2b3",
       "tags": [
         "gaming",
         "warcraft",

--- a/index.json
+++ b/index.json
@@ -5,7 +5,7 @@
       "name": "abbot",
       "display_name": "The Abbot (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Abbot voice lines from Stronghold Crusader — scheming monastery lord",
+      "description": "The Abbot voice lines from Stronghold Crusader \u2014 scheming monastery lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -83,7 +83,7 @@
     },
     {
       "name": "acolyte_es",
-      "display_name": "Acólito Muertos Vivientes Warcraft III (ES)",
+      "display_name": "Ac\u00f3lito Muertos Vivientes Warcraft III (ES)",
       "version": "1.0.2",
       "description": "Spanish Undead Acolyte sound pack from Warcraft III",
       "author": {
@@ -163,9 +163,9 @@
     },
     {
       "name": "ae_qianyu",
-      "display_name": "明日方舟:终末地 陈千语",
+      "display_name": "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730 \u9648\u5343\u8bed",
       "version": "1.0.4",
-      "description": "明日方舟:终末地 陈千语 语音包",
+      "description": "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730 \u9648\u5343\u8bed \u8bed\u97f3\u5305",
       "author": {
         "name": "LiRiu",
         "github": "LiRiu"
@@ -189,7 +189,7 @@
       "manifest_sha256": "50fd5866b2f025deba93723ceae9aa77ef88302efa7915711d881222c391d67b",
       "tags": [
         "gaming",
-        "明日方舟:终末地",
+        "\u660e\u65e5\u65b9\u821f:\u7ec8\u672b\u5730",
         "arknights:endfield"
       ],
       "preview_sounds": [
@@ -697,7 +697,7 @@
       "name": "arc-raiders-emotes",
       "display_name": "Arc Raiders Emotes",
       "version": "1.0.0",
-      "description": "Arc Raiders emote voice lines — hey there, let's boogie, don't shoot, and more",
+      "description": "Arc Raiders emote voice lines \u2014 hey there, let's boogie, don't shoot, and more",
       "author": {
         "name": "Buupu",
         "github": "Buupu"
@@ -847,9 +847,9 @@
     },
     {
       "name": "arthas_ru",
-      "display_name": "Артас Рыцарь Смерти (Russian)",
+      "display_name": "\u0410\u0440\u0442\u0430\u0441 \u0420\u044b\u0446\u0430\u0440\u044c \u0421\u043c\u0435\u0440\u0442\u0438 (Russian)",
       "version": "1.0.0",
-      "description": "WC3 Death Knight Arthas — all 20 Russian voice lines mapped to CESP categories",
+      "description": "WC3 Death Knight Arthas \u2014 all 20 Russian voice lines mapped to CESP categories",
       "author": {
         "name": "samokay",
         "github": "samokay"
@@ -1014,9 +1014,9 @@
     },
     {
       "name": "boris_ru",
-      "display_name": "Дед Борис (Russian)",
+      "display_name": "\u0414\u0435\u0434 \u0411\u043e\u0440\u0438\u0441 (Russian)",
       "version": "1.0.0",
-      "description": "Дед Борис — AI-generated tired Russian village grandpa commenting on your code. Gruff but warm.",
+      "description": "\u0414\u0435\u0434 \u0411\u043e\u0440\u0438\u0441 \u2014 AI-generated tired Russian village grandpa commenting on your code. Gruff but warm.",
       "author": {
         "name": "malakhov-dmitrii",
         "github": "malakhov-dmitrii"
@@ -1179,7 +1179,7 @@
       "name": "caliph",
       "display_name": "The Caliph (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Caliph voice lines from Stronghold Crusader — diplomatic desert lord",
+      "description": "The Caliph voice lines from Stronghold Crusader \u2014 diplomatic desert lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -1421,7 +1421,7 @@
       "name": "charlie_sheen",
       "display_name": "Charlie Sheen",
       "version": "1.0.0",
-      "description": "Charlie Sheen's iconic interview quotes — Winning, tiger blood, and more.",
+      "description": "Charlie Sheen's iconic interview quotes \u2014 Winning, tiger blood, and more.",
       "author": {
         "name": "rootbarb",
         "github": "rootbarb"
@@ -1457,9 +1457,9 @@
     },
     {
       "name": "claptrap-fr",
-      "display_name": "ClapTrap (FR) — Borderlands 2",
+      "display_name": "ClapTrap (FR) \u2014 Borderlands 2",
       "version": "1.0.0",
-      "description": "Répliques de ClapTrap en français depuis Borderlands 2",
+      "description": "R\u00e9pliques de ClapTrap en fran\u00e7ais depuis Borderlands 2",
       "author": {
         "name": "Jean-Baptiste Choquet",
         "github": "Jechoque42"
@@ -1624,7 +1624,7 @@
       "name": "cute-minimal",
       "display_name": "Cute UI",
       "version": "1.0.1",
-      "description": "Simple, cute UI/UX interface sounds — light and playful coding event feedback",
+      "description": "Simple, cute UI/UX interface sounds \u2014 light and playful coding event feedback",
       "author": {
         "name": "Mark Chitty",
         "github": "TechPdM"
@@ -1897,7 +1897,7 @@
       "name": "djkhaled",
       "display_name": "DJ Khaled",
       "version": "1.0.0",
-      "description": "DJ Khaled catchphrases as coding notification sounds — Another one! We the best! Major key alert!",
+      "description": "DJ Khaled catchphrases as coding notification sounds \u2014 Another one! We the best! Major key alert!",
       "author": {
         "name": "mevinmathew23",
         "github": "mevinmathew23"
@@ -2142,7 +2142,7 @@
       "name": "dota2_ember_spirit",
       "display_name": "Ember Spirit (Dota 2)",
       "version": "1.0.0",
-      "description": "Ember Spirit (Dota 2) sound pack — 'Balance in all things.'",
+      "description": "Ember Spirit (Dota 2) sound pack \u2014 'Balance in all things.'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -2182,7 +2182,7 @@
       "name": "dota2_invoker",
       "display_name": "Invoker (Dota 2)",
       "version": "1.0.0",
-      "description": "Invoker (Dota 2) sound pack — 'So begins a new age of knowledge.'",
+      "description": "Invoker (Dota 2) sound pack \u2014 'So begins a new age of knowledge.'",
       "author": {
         "name": "bwarren2",
         "github": "bwarren2"
@@ -2222,7 +2222,7 @@
       "name": "dota2_phantom_lancer",
       "display_name": "Phantom Lancer (Dota 2)",
       "version": "1.0.0",
-      "description": "Phantom Lancer (Dota 2) sound pack — 'From one: an army.'",
+      "description": "Phantom Lancer (Dota 2) sound pack \u2014 'From one: an army.'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -2262,7 +2262,7 @@
       "name": "dota2_witch_doctor",
       "display_name": "Witch Doctor (Dota 2)",
       "version": "1.0.0",
-      "description": "Witch Doctor (Dota 2) sound pack — 'De Doctor is in!'",
+      "description": "Witch Doctor (Dota 2) sound pack \u2014 'De Doctor is in!'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -2302,7 +2302,7 @@
       "name": "dota2_zeus",
       "display_name": "Zeus (Dota 2)",
       "version": "1.0.0",
-      "description": "Zeus (Dota 2) sound pack — 'Your god has arrived.'",
+      "description": "Zeus (Dota 2) sound pack \u2014 'Your god has arrived.'",
       "author": {
         "name": "kmelkon",
         "github": "kmelkon"
@@ -2342,7 +2342,7 @@
       "name": "dreamy-minimal",
       "display_name": "Dreamy Beeps",
       "version": "1.0.1",
-      "description": "Soft, dreamy tonal beeps — gentle and unobtrusive coding event sounds",
+      "description": "Soft, dreamy tonal beeps \u2014 gentle and unobtrusive coding event sounds",
       "author": {
         "name": "Mark Chitty",
         "github": "TechPdM"
@@ -2378,7 +2378,7 @@
     },
     {
       "name": "ds1-carvings",
-      "display_name": "Dark Souls – Carvings",
+      "display_name": "Dark Souls \u2013 Carvings",
       "version": "1.0.0",
       "description": "Gough's infamous carvings from Dark Souls as sound effects for various events.",
       "author": {
@@ -2417,7 +2417,7 @@
     },
     {
       "name": "ds1-siegmeyer",
-      "display_name": "Dark Souls – Siegmeyer of Catarina",
+      "display_name": "Dark Souls \u2013 Siegmeyer of Catarina",
       "version": "1.0.1",
       "description": "A sound pack with a big heart and bigger armor.",
       "author": {
@@ -2460,7 +2460,7 @@
     },
     {
       "name": "ds1-solaire",
-      "display_name": "Dark Souls – Solaire of Astora",
+      "display_name": "Dark Souls \u2013 Solaire of Astora",
       "version": "1.0.2",
       "description": "A sound pack for true warriors of sunlight.",
       "author": {
@@ -3273,7 +3273,7 @@
       "name": "emir",
       "display_name": "The Emir (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Emir voice lines from Stronghold Crusader — fierce Arabian lord",
+      "description": "The Emir voice lines from Stronghold Crusader \u2014 fierce Arabian lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -3395,7 +3395,7 @@
       "name": "frederick",
       "display_name": "Emperor Frederick (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "Emperor Frederick voice lines from Stronghold Crusader — noble crusader emperor",
+      "description": "Emperor Frederick voice lines from Stronghold Crusader \u2014 noble crusader emperor",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -3916,7 +3916,7 @@
     },
     {
       "name": "high_elf_builder_ru",
-      "display_name": "Строитель Высших Эльфов (Russian)",
+      "display_name": "\u0421\u0442\u0440\u043e\u0438\u0442\u0435\u043b\u044c \u0412\u044b\u0441\u0448\u0438\u0445 \u042d\u043b\u044c\u0444\u043e\u0432 (Russian)",
       "version": "1.1.0",
       "description": "High Elf Builder voice lines from Warcraft III (Russian)",
       "author": {
@@ -3957,7 +3957,7 @@
     },
     {
       "name": "honor_of_kings",
-      "display_name": "Honor of Kings (王者荣耀)",
+      "display_name": "Honor of Kings (\u738b\u8005\u8363\u8000)",
       "version": "1.0.2",
       "description": "Honor of Kings game announcement voice lines and XiShi character VO",
       "author": {
@@ -4045,7 +4045,7 @@
       "name": "impossible-mission",
       "display_name": "Impossible Mission (C64, 1984)",
       "version": "1.0.0",
-      "description": "Digitized speech from Impossible Mission (Epyx, 1984) for the Commodore 64 — one of the earliest examples of voice synthesis in a home computer game.",
+      "description": "Digitized speech from Impossible Mission (Epyx, 1984) for the Commodore 64 \u2014 one of the earliest examples of voice synthesis in a home computer game.",
       "author": {
         "name": "trjh",
         "github": "trjh"
@@ -4746,7 +4746,7 @@
       "name": "lol_fiddlesticks",
       "display_name": "Fiddlesticks",
       "version": "1.0.0",
-      "description": "Fiddlesticks (Rework) voice lines from League of Legends — the ancient fear demon",
+      "description": "Fiddlesticks (Rework) voice lines from League of Legends \u2014 the ancient fear demon",
       "author": {
         "name": "huynhtan",
         "github": "danhuynhdev"
@@ -4826,7 +4826,7 @@
       "name": "lol_fiddlesticks_surprise_party",
       "display_name": "Fiddlesticks - Surprise Party",
       "version": "1.0.0",
-      "description": "Surprise Party Fiddlesticks skin voice lines from League of Legends — the demon clown",
+      "description": "Surprise Party Fiddlesticks skin voice lines from League of Legends \u2014 the demon clown",
       "author": {
         "name": "huynhtan",
         "github": "danhuynhdev"
@@ -4908,7 +4908,7 @@
       "name": "mambo_pack",
       "display_name": "Mambo Pack",
       "version": "1.0.0",
-      "description": "Fun yet restrained Mambo voice pack — Chinese meme-flavored coding companion",
+      "description": "Fun yet restrained Mambo voice pack \u2014 Chinese meme-flavored coding companion",
       "author": {
         "name": "nicoaz",
         "github": "nicoaz"
@@ -4948,9 +4948,9 @@
       "name": "marcel",
       "display_name": "Marcel",
       "version": "1.0.0",
-      "description": "Legendary quotes of Marcel Merčiak.",
+      "description": "Legendary quotes of Marcel Mer\u010diak.",
       "author": {
-        "name": "Marián Čamák",
+        "name": "Mari\u00e1n \u010cam\u00e1k",
         "github": "mcamak"
       },
       "trust_tier": "community",
@@ -4985,7 +4985,7 @@
       "name": "marshal",
       "display_name": "The Marshal (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Marshal voice lines from Stronghold Crusader — loyal European lord",
+      "description": "The Marshal voice lines from Stronghold Crusader \u2014 loyal European lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -5149,11 +5149,11 @@
     },
     {
       "name": "milujipraci",
-      "display_name": "Miluji Práci",
+      "display_name": "Miluji Pr\u00e1ci",
       "version": "1.0.0",
-      "description": "Legendary quotes of Luboš fixing Lakatoš.",
+      "description": "Legendary quotes of Lubo\u0161 fixing Lakato\u0161.",
       "author": {
-        "name": "František Záhora",
+        "name": "Franti\u0161ek Z\u00e1hora",
         "github": "arguit"
       },
       "trust_tier": "community",
@@ -5187,7 +5187,7 @@
       "version": "1.0.1",
       "description": "Villager sound pack from Minecraft.",
       "author": {
-        "name": "Eric Keränen",
+        "name": "Eric Ker\u00e4nen",
         "github": "Mahamurahti"
       },
       "trust_tier": "community",
@@ -5265,7 +5265,7 @@
       "name": "modern-varied",
       "display_name": "Modern GUI",
       "version": "1.0.1",
-      "description": "Futuristic synth UI sounds — hightech confirms, cybernetic alerts, and power-up sweeps",
+      "description": "Futuristic synth UI sounds \u2014 hightech confirms, cybernetic alerts, and power-up sweeps",
       "author": {
         "name": "Mark Chitty",
         "github": "TechPdM"
@@ -5495,7 +5495,7 @@
       "name": "nezuai-varied",
       "display_name": "UI Sound Design",
       "version": "1.0.1",
-      "description": "Designed UI sound effects — whooshes, beeps, sweeps, and thuds for coding events",
+      "description": "Designed UI sound effects \u2014 whooshes, beeps, sweeps, and thuds for coding events",
       "author": {
         "name": "Mark Chitty",
         "github": "TechPdM"
@@ -5533,7 +5533,7 @@
       "name": "nightflame-minimal",
       "display_name": "Nightflame Menu UI",
       "version": "1.0.1",
-      "description": "Minimal UI sound effects pack — sweeps, whooshes, and buzzy tones for coding event feedback",
+      "description": "Minimal UI sound effects pack \u2014 sweeps, whooshes, and buzzy tones for coding event feedback",
       "author": {
         "name": "Mark Chitty",
         "github": "TechPdM"
@@ -5570,7 +5570,7 @@
       "name": "nizar",
       "display_name": "Nizar (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "Nizar voice lines from Stronghold Crusader — cunning assassin lord",
+      "description": "Nizar voice lines from Stronghold Crusader \u2014 cunning assassin lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -5864,7 +5864,7 @@
       "name": "op-kurtlar-vadisi",
       "display_name": "Kurtlar Vadisi Sound Pack",
       "version": "1.1.0",
-      "description": "Kurtlar Vadisi Sound Pack (Episodes 1–97)",
+      "description": "Kurtlar Vadisi Sound Pack (Episodes 1\u201397)",
       "author": {
         "name": "Ismail Sefa Nazlim",
         "github": "maskapsiz"
@@ -5947,9 +5947,9 @@
     },
     {
       "name": "otto",
-      "display_name": "电棍otto",
+      "display_name": "\u7535\u68cdotto",
       "version": "1.0.0",
-      "description": "大家好啊，我是电棍",
+      "description": "\u5927\u5bb6\u597d\u554a\uff0c\u6211\u662f\u7535\u68cd",
       "author": {
         "name": "Bielelele",
         "github": "Biatbang"
@@ -5976,8 +5976,8 @@
       "manifest_sha256": "0ce67cd3cc429661546ab708046eef15996df858c07261e8e440c81bf9a2097e",
       "tags": [
         "otto",
-        "电棍",
-        "侯国玉"
+        "\u7535\u68cd",
+        "\u4faf\u56fd\u7389"
       ],
       "preview_sounds": [
         "session_start_1.mp3",
@@ -6068,9 +6068,9 @@
     },
     {
       "name": "peasant_cz",
-      "display_name": "Lidský rolník (CZ)",
+      "display_name": "Lidsk\u00fd roln\u00edk (CZ)",
       "version": "1.0.0",
-      "description": "Lidský rolník (CZ) sound pack from Warcraft III",
+      "description": "Lidsk\u00fd roln\u00edk (CZ) sound pack from Warcraft III",
       "author": {
         "name": "vojtabiberle",
         "github": "vojtabiberle"
@@ -6268,9 +6268,9 @@
     },
     {
       "name": "peon_cz",
-      "display_name": "Orčí peón (CZ)",
+      "display_name": "Or\u010d\u00ed pe\u00f3n (CZ)",
       "version": "1.0.0",
-      "description": "Orčí peón (CZ) sound pack from Warcraft III",
+      "description": "Or\u010d\u00ed pe\u00f3n (CZ) sound pack from Warcraft III",
       "author": {
         "name": "vojtabiberle",
         "github": "vojtabiberle"
@@ -6552,7 +6552,7 @@
       "name": "philip",
       "display_name": "King Philip (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "King Philip voice lines from Stronghold Crusader — proud king of France",
+      "description": "King Philip voice lines from Stronghold Crusader \u2014 proud king of France",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -6592,7 +6592,7 @@
       "name": "pig",
       "display_name": "The Pig (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Pig voice lines from Stronghold Crusader — brutal villain lord",
+      "description": "The Pig voice lines from Stronghold Crusader \u2014 brutal villain lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -6834,7 +6834,7 @@
       "name": "protoss",
       "display_name": "Protoss (StarCraft)",
       "version": "1.0.0",
-      "description": "StarCraft Protoss voice lines and sound effects — en taro Adun!",
+      "description": "StarCraft Protoss voice lines and sound effects \u2014 en taro Adun!",
       "author": {
         "name": "Cody Born",
         "github": "codyborn"
@@ -7256,7 +7256,7 @@
       "name": "rat",
       "display_name": "The Rat (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Rat voice lines from Stronghold Crusader — scheming cowardly villain",
+      "description": "The Rat voice lines from Stronghold Crusader \u2014 scheming cowardly villain",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -7423,7 +7423,7 @@
       "name": "richard",
       "display_name": "King Richard (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "King Richard voice lines from Stronghold Crusader — noble English crusader king",
+      "description": "King Richard voice lines from Stronghold Crusader \u2014 noble English crusader king",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -7626,7 +7626,7 @@
       "name": "saladin",
       "display_name": "Saladin (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "Saladin voice lines from Stronghold Crusader — honourable sultan of Egypt",
+      "description": "Saladin voice lines from Stronghold Crusader \u2014 honourable sultan of Egypt",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -7883,9 +7883,9 @@
     },
     {
       "name": "sc2_scv_kr",
-      "display_name": "건설로봇 SCV (StarCraft II, 한국어)",
+      "display_name": "\uac74\uc124\ub85c\ubd07 SCV (StarCraft II, \ud55c\uad6d\uc5b4)",
       "version": "1.0.0",
-      "description": "테란 건설로봇(SCV) 한국어 음성 — StarCraft II Korean voice lines",
+      "description": "\ud14c\ub780 \uac74\uc124\ub85c\ubd07(SCV) \ud55c\uad6d\uc5b4 \uc74c\uc131 \u2014 StarCraft II Korean voice lines",
       "author": {
         "name": "heecheonkim",
         "github": "hekkim"
@@ -8133,7 +8133,7 @@
       "name": "sc_firebat",
       "display_name": "StarCraft Firebat",
       "version": "2.0.0",
-      "description": "StarCraft Firebat sound pack — 17 SC1 voice lines across all 7 CESP categories, featuring 'Need a light?' and propane references",
+      "description": "StarCraft Firebat sound pack \u2014 17 SC1 voice lines across all 7 CESP categories, featuring 'Need a light?' and propane references",
       "author": {
         "name": "kschmidtjr1",
         "github": "kschmidtjr1"
@@ -8286,7 +8286,7 @@
       "name": "sc_marine",
       "display_name": "StarCraft Marine",
       "version": "1.0.0",
-      "description": "StarCraft Marine sound pack — iconic lines including 'Rock 'n' roll!' and 'You want a piece of me, boy?'",
+      "description": "StarCraft Marine sound pack \u2014 iconic lines including 'Rock 'n' roll!' and 'You want a piece of me, boy?'",
       "author": {
         "name": "harrymunro",
         "github": "harrymunro"
@@ -8326,7 +8326,7 @@
       "name": "sc_medic",
       "display_name": "StarCraft Medic",
       "version": "2.0.0",
-      "description": "StarCraft Medic sound pack — 16 SC1 voice lines across all 7 CESP categories, featuring 'He's dead, Jim' and medical humor",
+      "description": "StarCraft Medic sound pack \u2014 16 SC1 voice lines across all 7 CESP categories, featuring 'He's dead, Jim' and medical humor",
       "author": {
         "name": "kschmidtjr1",
         "github": "kschmidtjr1"
@@ -8403,7 +8403,7 @@
       "name": "sc_scv",
       "display_name": "StarCraft SCV",
       "version": "2.0.0",
-      "description": "StarCraft SCV sound pack — expanded with 19 sounds across all 7 CESP categories",
+      "description": "StarCraft SCV sound pack \u2014 expanded with 19 sounds across all 7 CESP categories",
       "author": {
         "name": "harrymunro",
         "github": "harrymunro"
@@ -8443,7 +8443,7 @@
       "name": "sc_tank",
       "display_name": "StarCraft Siege Tank",
       "version": "2.0.0",
-      "description": "StarCraft Siege Tank sound pack — 14 SC1 voice lines across all 7 CESP categories, featuring Ride of the Valkyries and 'drop the hammer'",
+      "description": "StarCraft Siege Tank sound pack \u2014 14 SC1 voice lines across all 7 CESP categories, featuring Ride of the Valkyries and 'drop the hammer'",
       "author": {
         "name": "kschmidtjr1",
         "github": "kschmidtjr1"
@@ -8716,7 +8716,7 @@
       "name": "sheriff",
       "display_name": "The Sheriff (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Sheriff voice lines from Stronghold Crusader — greedy corrupt villain",
+      "description": "The Sheriff voice lines from Stronghold Crusader \u2014 greedy corrupt villain",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -8798,7 +8798,7 @@
       "name": "silicon_valley",
       "display_name": "Silicon Valley",
       "version": "2.2.0",
-      "description": "Quotes from Silicon Valley — Erlich, Gilfoyle, Russ Hanneman, Jian Yang. English + Russian dubbed by «Кубик в кубике» (59 clips with swearing)",
+      "description": "Quotes from Silicon Valley \u2014 Erlich, Gilfoyle, Russ Hanneman, Jian Yang. English + Russian dubbed by \u00ab\u041a\u0443\u0431\u0438\u043a \u0432 \u043a\u0443\u0431\u0438\u043a\u0435\u00bb (59 clips with swearing)",
       "author": {
         "name": "rustam",
         "github": "fortunto2"
@@ -8883,7 +8883,7 @@
       "name": "snake",
       "display_name": "The Snake (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Snake voice lines from Stronghold Crusader — treacherous villain lord",
+      "description": "The Snake voice lines from Stronghold Crusader \u2014 treacherous villain lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -9139,7 +9139,7 @@
       "name": "southpark_cartman",
       "display_name": "Cartman (South Park)",
       "version": "1.0.0",
-      "description": "Eric Cartman quotes for your Claude Code notifications. 25 AI-generated clips across 7 categories (FakeYou TTS — Eric Cartman Angry model).",
+      "description": "Eric Cartman quotes for your Claude Code notifications. 25 AI-generated clips across 7 categories (FakeYou TTS \u2014 Eric Cartman Angry model).",
       "author": {
         "name": "bdrang",
         "github": "BaraqD"
@@ -9182,7 +9182,7 @@
       "name": "speaki",
       "display_name": "Petite Speaki",
       "version": "1.0.0",
-      "description": "Petite Speaki voice pack from Trickcal Chibi Go — adorable Korean character sounds for your coding sessions",
+      "description": "Petite Speaki voice pack from Trickcal Chibi Go \u2014 adorable Korean character sounds for your coding sessions",
       "author": {
         "name": "cjna",
         "github": "CJNA"
@@ -9303,9 +9303,9 @@
     },
     {
       "name": "starrail-kafka-peon-pack",
-      "display_name": "崩坏星穹铁道-卡芙卡语音包",
+      "display_name": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
       "version": "1.0.1",
-      "description": "崩坏星穹铁道-卡芙卡语音包",
+      "description": "\u5d29\u574f\u661f\u7a79\u94c1\u9053-\u5361\u8299\u5361\u8bed\u97f3\u5305",
       "author": {
         "name": "0w0miki",
         "github": "0w0miki"
@@ -9472,7 +9472,7 @@
       "name": "stronghold-peasant-es",
       "display_name": "Stronghold Peasant (ES)",
       "version": "1.0.1",
-      "description": "Spanish peasant voice lines from Stronghold HD (Firefly Studios) — medieval worker responding to your commands",
+      "description": "Spanish peasant voice lines from Stronghold HD (Firefly Studios) \u2014 medieval worker responding to your commands",
       "author": {
         "name": "Matias Saggiorato",
         "github": "msaggiorato"
@@ -9514,7 +9514,7 @@
       "name": "sultan",
       "display_name": "The Sultan (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Sultan voice lines from Stronghold Crusader — powerful desert sultan",
+      "description": "The Sultan voice lines from Stronghold Crusader \u2014 powerful desert sultan",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -9720,9 +9720,9 @@
     },
     {
       "name": "teemo-kr",
-      "display_name": "티모 (한국어)",
+      "display_name": "\ud2f0\ubaa8 (\ud55c\uad6d\uc5b4)",
       "version": "1.0.1",
-      "description": "리그 오브 레전드 2024 ASU 티모 한국어 음성팩. 밴들시티 정찰대장 티모 출동!",
+      "description": "\ub9ac\uadf8 \uc624\ube0c \ub808\uc804\ub4dc 2024 ASU \ud2f0\ubaa8 \ud55c\uad6d\uc5b4 \uc74c\uc131\ud329. \ubc34\ub4e4\uc2dc\ud2f0 \uc815\ucc30\ub300\uc7a5 \ud2f0\ubaa8 \ucd9c\ub3d9!",
       "author": {
         "name": "hphannah",
         "github": "hphannah"
@@ -9763,7 +9763,7 @@
       "name": "tekken3_announcer",
       "display_name": "Announcer (Tekken 3)",
       "version": "1.0.0",
-      "description": "Tekken 3 announcer voice lines — Fight, K.O., You win!, and more.",
+      "description": "Tekken 3 announcer voice lines \u2014 Fight, K.O., You win!, and more.",
       "author": {
         "name": "rootbarb",
         "github": "rootbarb"
@@ -10432,7 +10432,7 @@
         "user.spam"
       ],
       "language": "en",
-      "license": "All audio © Riot Games — personal/non-commercial use only",
+      "license": "All audio \u00a9 Riot Games \u2014 personal/non-commercial use only",
       "sound_count": 68,
       "total_size_bytes": 2320270,
       "source_repo": "valer23/openpeon-tryndamere-pack",
@@ -10617,7 +10617,7 @@
       "name": "warcraft3-czech",
       "display_name": "Warcraft III - Czech Peasant & Knight",
       "version": "1.0.0",
-      "description": "Warcraft III Peasant & Knight sound alerts for Claude Code. Czech dubbed voices from the iconic RTS. Huráááá do práce!",
+      "description": "Warcraft III Peasant & Knight sound alerts for Claude Code. Czech dubbed voices from the iconic RTS. Hur\u00e1\u00e1\u00e1\u00e1 do pr\u00e1ce!",
       "author": {
         "name": "Tomas Pflanzer",
         "github": "gizmax"
@@ -10657,7 +10657,7 @@
       "name": "warcraft3-mix",
       "display_name": "Warcraft III Mix CZ",
       "version": "1.0.0",
-      "description": "Mix ikonických českých hlášek z Warcraft III od různých jednotek a hrdinů.",
+      "description": "Mix ikonick\u00fdch \u010desk\u00fdch hl\u00e1\u0161ek z Warcraft III od r\u016fzn\u00fdch jednotek a hrdin\u016f.",
       "author": {
         "name": "SgtMarmite",
         "github": "SgtMarmite"
@@ -10698,7 +10698,7 @@
       "name": "wazir",
       "display_name": "The Wazir (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Wazir voice lines from Stronghold Crusader — scheming Arabian lord",
+      "description": "The Wazir voice lines from Stronghold Crusader \u2014 scheming Arabian lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -10856,9 +10856,9 @@
     },
     {
       "name": "wc2_peon_ru",
-      "display_name": "Орк-батрак (Russian)",
+      "display_name": "\u041e\u0440\u043a-\u0431\u0430\u0442\u0440\u0430\u043a (Russian)",
       "version": "1.0.1",
-      "description": "Орк-батрак из Warcraft II (русская озвучка от СПК)",
+      "description": "\u041e\u0440\u043a-\u0431\u0430\u0442\u0440\u0430\u043a \u0438\u0437 Warcraft II (\u0440\u0443\u0441\u0441\u043a\u0430\u044f \u043e\u0437\u0432\u0443\u0447\u043a\u0430 \u043e\u0442 \u0421\u041f\u041a)",
       "author": {
         "name": "Artyom Mezin",
         "github": "Sogl"
@@ -11156,7 +11156,7 @@
       "name": "wc3_lich",
       "display_name": "Undead Lich (Warcraft III)",
       "version": "1.0.0",
-      "description": "Undead Lich hero and Kel'Thuzad voice lines from Warcraft III — 44 sounds across both characters",
+      "description": "Undead Lich hero and Kel'Thuzad voice lines from Warcraft III \u2014 44 sounds across both characters",
       "author": {
         "name": "iamunhoz",
         "github": "iamunhoz"
@@ -11321,7 +11321,7 @@
       "name": "wolf",
       "display_name": "The Wolf (Stronghold Crusader)",
       "version": "1.2.1",
-      "description": "The Wolf voice lines from Stronghold Crusader — ruthless villain lord",
+      "description": "The Wolf voice lines from Stronghold Crusader \u2014 ruthless villain lord",
       "author": {
         "name": "Marko Jevic",
         "github": "koyev"
@@ -11521,7 +11521,7 @@
       "name": "wrecking_ball",
       "display_name": "Wrecking Ball (Overwatch)",
       "version": "1.0.0",
-      "description": "Hammond / Wrecking Ball voice lines from Overwatch — the champion hamster pilot",
+      "description": "Hammond / Wrecking Ball voice lines from Overwatch \u2014 the champion hamster pilot",
       "author": {
         "name": "wahidfaird",
         "github": "wahidfaird"
@@ -11561,7 +11561,7 @@
     },
     {
       "name": "yasuo-pack",
-      "display_name": "Yasuo(亚索)",
+      "display_name": "Yasuo(\u4e9a\u7d22)",
       "version": "1.1.0",
       "description": "Yasuo voice lines from League of Legends (Chinese voice version)",
       "author": {
@@ -11846,6 +11846,44 @@
       ],
       "added": "2026-02-25",
       "updated": "2026-02-25"
+    },
+    {
+      "name": "zugzug",
+      "display_name": "Zug Zug",
+      "version": "1.0.0",
+      "description": "A sound pack inspired by Warcraft peon responses",
+      "author": {
+        "name": "dmurai",
+        "github": "dmurai"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "resource.limit",
+        "session.end",
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "task.progress",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 14,
+      "total_size_bytes": 154426,
+      "source_repo": "dmurai/zugzug",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "9bae8d8cccaeddda2ec99412b949845aeb44fbffdca4c798c96dd77ccde78388",
+      "tags": [
+        "gaming",
+        "warcraft",
+        "rts",
+        "blizzard"
+      ],
+      "added": "2026-04-11",
+      "updated": "2026-04-11"
     }
   ],
   "total_packs": 295


### PR DESCRIPTION
## Summary
- Adds the **Zug Zug** sound pack — Warcraft peon-inspired responses
- 14 sound files (.wav), 154 KB total
- Covers all 6 core categories + all 3 extended categories
- Source repo: https://github.com/dmurai/zugzug (tagged `v1.0.0`)

## Checklist
- [x] Pack passes CESP v1.0 spec validation
- [x] `sha256` hashes included on all sound entries
- [x] `manifest_sha256` computed and included
- [x] Entry added in alphabetical order
- [x] Source repo is public with tagged release

🤖 Generated with [Claude Code](https://claude.com/claude-code)