### PR TITLE
Add 3 Age of Empires Turkish villager packs

### DIFF
--- a/index.json
+++ b/index.json
@@ -619,6 +619,7 @@
       "trust_tier": "community",
       "categories": [
         "input.required",
+        "resource.limit",
         "session.start",
         "task.acknowledge",
         "task.complete",
@@ -632,7 +633,7 @@
       "source_repo": "yusufkinatas/peon-ping-custom-packs",
       "source_ref": "v1.0.0",
       "source_path": "aoe2-villager-turkish-female",
-      "manifest_sha256": "4a3094bf46c5d7c08e4ac1a4763a51345191b747f073efdcbd794f3a3e6a814e",
+      "manifest_sha256": "9d6011a9e596eef1a607e1fb607060ba65538eafc573e298705c16a5f8efbdd6",
       "tags": [
         "gaming",
         "aoe",
@@ -659,6 +660,7 @@
       "trust_tier": "community",
       "categories": [
         "input.required",
+        "resource.limit",
         "session.start",
         "task.acknowledge",
         "task.complete",
@@ -672,7 +674,7 @@
       "source_repo": "yusufkinatas/peon-ping-custom-packs",
       "source_ref": "v1.0.0",
       "source_path": "aoe2-villager-turkish-male",
-      "manifest_sha256": "893cce2b5ff6a32bcb4bc89a837557caa50953c33429f4d3eaf0215823298989",
+      "manifest_sha256": "b25d44c89654a9b322ff7a1f3d3f4e6d13372d1b9a42d0c46c6757a79469e027",
       "tags": [
         "gaming",
         "aoe",

--- a/index.json
+++ b/index.json
@@ -608,6 +608,127 @@
       "updated": "2026-02-12"
     },
     {
+      "name": "aoe2-villager-turkish-female",
+      "display_name": "Age of Empires 2 Turkish (Female)",
+      "version": "1.0.0",
+      "description": "Female Turkish villager voice lines from Age of Empires II",
+      "author": {
+        "name": "Yusuf Kinatas",
+        "github": "yusufkinatas"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "user.spam"
+      ],
+      "language": "tr",
+      "license": "MIT",
+      "sound_count": 18,
+      "total_size_bytes": 228642,
+      "source_repo": "yusufkinatas/peon-ping-custom-packs",
+      "source_ref": "v1.0.0",
+      "source_path": "aoe2-villager-turkish-female",
+      "manifest_sha256": "4a3094bf46c5d7c08e4ac1a4763a51345191b747f073efdcbd794f3a3e6a814e",
+      "tags": [
+        "gaming",
+        "aoe",
+        "aoe2",
+        "rts",
+        "turkish"
+      ],
+      "preview_sounds": [
+        "Evet_F.ogg",
+        "Oduncu_F.ogg"
+      ],
+      "added": "2026-04-15",
+      "updated": "2026-04-15"
+    },
+    {
+      "name": "aoe2-villager-turkish-male",
+      "display_name": "Age of Empires 2 Turkish (Male)",
+      "version": "1.0.0",
+      "description": "Male Turkish villager voice lines from Age of Empires II",
+      "author": {
+        "name": "Yusuf Kinatas",
+        "github": "yusufkinatas"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "user.spam"
+      ],
+      "language": "tr",
+      "license": "MIT",
+      "sound_count": 18,
+      "total_size_bytes": 259557,
+      "source_repo": "yusufkinatas/peon-ping-custom-packs",
+      "source_ref": "v1.0.0",
+      "source_path": "aoe2-villager-turkish-male",
+      "manifest_sha256": "893cce2b5ff6a32bcb4bc89a837557caa50953c33429f4d3eaf0215823298989",
+      "tags": [
+        "gaming",
+        "aoe",
+        "aoe2",
+        "rts",
+        "turkish"
+      ],
+      "preview_sounds": [
+        "Evet_M.ogg",
+        "Oduncu_M.ogg"
+      ],
+      "added": "2026-04-15",
+      "updated": "2026-04-15"
+    },
+    {
+      "name": "aoe3-villager-turkish",
+      "display_name": "Age of Empires 3 Turkish",
+      "version": "1.0.0",
+      "description": "Ottoman Turkish villager voice lines from Age of Empires III",
+      "author": {
+        "name": "Yusuf Kinatas",
+        "github": "yusufkinatas"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "resource.limit",
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error"
+      ],
+      "language": "tr",
+      "license": "MIT",
+      "sound_count": 15,
+      "total_size_bytes": 438548,
+      "source_repo": "yusufkinatas/peon-ping-custom-packs",
+      "source_ref": "v1.0.0",
+      "source_path": "aoe3-villager-turkish",
+      "manifest_sha256": "fa102ca835724330fb3b1a8cafde640c061ebb6b39823949efd0f9e8146455eb",
+      "tags": [
+        "gaming",
+        "aoe",
+        "aoe3",
+        "rts",
+        "turkish",
+        "ottoman"
+      ],
+      "preview_sounds": [
+        "Selam.ogg",
+        "Oduncu.ogg"
+      ],
+      "added": "2026-04-15",
+      "updated": "2026-04-15"
+    },
+    {
       "name": "aoe4_fr_imperial",
       "display_name": "Age of Empires IV - French Villager Voices",
       "version": "1.0.2",

--- a/index.json
+++ b/index.json
@@ -610,7 +610,7 @@
     {
       "name": "aoe2-villager-turkish-female",
       "display_name": "Age of Empires 2 Turkish (Female)",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Female Turkish villager voice lines from Age of Empires II",
       "author": {
         "name": "Yusuf Kinatas",
@@ -631,9 +631,9 @@
       "sound_count": 18,
       "total_size_bytes": 228642,
       "source_repo": "yusufkinatas/peon-ping-custom-packs",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": "aoe2-villager-turkish-female",
-      "manifest_sha256": "9d6011a9e596eef1a607e1fb607060ba65538eafc573e298705c16a5f8efbdd6",
+      "manifest_sha256": "327916a5e60a45bc470f826efd23be06e1fff31c3e91893c1c8be35fd43874c9",
       "tags": [
         "gaming",
         "aoe",
@@ -651,7 +651,7 @@
     {
       "name": "aoe2-villager-turkish-male",
       "display_name": "Age of Empires 2 Turkish (Male)",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Male Turkish villager voice lines from Age of Empires II",
       "author": {
         "name": "Yusuf Kinatas",
@@ -672,9 +672,9 @@
       "sound_count": 18,
       "total_size_bytes": 259557,
       "source_repo": "yusufkinatas/peon-ping-custom-packs",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": "aoe2-villager-turkish-male",
-      "manifest_sha256": "b25d44c89654a9b322ff7a1f3d3f4e6d13372d1b9a42d0c46c6757a79469e027",
+      "manifest_sha256": "a68b832338ed8c76ab04fbe27418bbe1939b91a6ab9336ee8e822b68a33fb909",
       "tags": [
         "gaming",
         "aoe",
@@ -692,7 +692,7 @@
     {
       "name": "aoe3-villager-turkish",
       "display_name": "Age of Empires 3 Turkish",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Ottoman Turkish villager voice lines from Age of Empires III",
       "author": {
         "name": "Yusuf Kinatas",
@@ -712,9 +712,9 @@
       "sound_count": 15,
       "total_size_bytes": 438548,
       "source_repo": "yusufkinatas/peon-ping-custom-packs",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": "aoe3-villager-turkish",
-      "manifest_sha256": "fa102ca835724330fb3b1a8cafde640c061ebb6b39823949efd0f9e8146455eb",
+      "manifest_sha256": "92a6f3d850ad6e9ba0b4ce26bb187f690b1f874fc4d8ba7e6c4c177090f4d1de",
       "tags": [
         "gaming",
         "aoe",


### PR DESCRIPTION
## Summary
- **aoe2-villager-turkish-female**: 18 female Turkish villager voice lines from Age of Empires II (select, task, resource, death sounds)
- **aoe2-villager-turkish-male**: 18 male Turkish villager voice lines from Age of Empires II (select, task, resource, death sounds)
- **aoe3-villager-turkish**: 15 Ottoman Turkish villager voice lines from Age of Empires III (select, task, resource, wounded sounds)

All packs source from `yusufkinatas/peon-ping-custom-packs` at tag `v1.0.0`.

## Checklist
- [x] Entries added in alphabetical order
- [x] All manifests include SHA256 hashes
- [x] Source repo is public
- [x] Release tag v1.0.0 created
- [x] Audio files under 1 MB each, total under 50 MB

🤖 Generated with [Claude Code](https://claude.com/claude-code)