### PR TITLE
Add orb-ping pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -6223,7 +6223,7 @@
     {
       "name": "orb-ping",
       "display_name": "Orb Ping",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "description": "A peonping pack using sounds from Tools for Humanity's Orb.",
       "author": {
         "name": "Seán Olszewski",
@@ -6232,20 +6232,22 @@
       "trust_tier": "community",
       "categories": [
         "input.required",
+        "resource.limit",
         "session.end",
         "session.start",
+        "task.acknowledge",
         "task.complete",
         "task.error",
         "task.progress"
       ],
       "language": "en",
       "license": "fair-use",
-      "sound_count": 18,
-      "total_size_bytes": 6714336,
+      "sound_count": 19,
+      "total_size_bytes": 6825880,
       "source_repo": "SeanROlszewski/orb-peonping",
-      "source_ref": "v1.0.1",
+      "source_ref": "v1.0.2",
       "source_path": ".",
-      "manifest_sha256": "e5659f17fd3cb3f6ef7344113dc8341def14be75a4ab040c38fceff13b70036c",
+      "manifest_sha256": "ffe02722306ad9e6a6964950bcdef351a3a80c7592e9453f2506aec46134048e",
       "tags": [
         "orb",
         "worldcoin",

--- a/index.json
+++ b/index.json
@@ -6221,6 +6221,46 @@
       "updated": "2026-03-10"
     },
     {
+      "name": "orb-ping",
+      "display_name": "Orb Ping",
+      "version": "1.0.1",
+      "description": "A peonping pack using sounds from Tools for Humanity's Orb.",
+      "author": {
+        "name": "Seán Olszewski",
+        "github": "SeanROlszewski"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "session.end",
+        "session.start",
+        "task.complete",
+        "task.error",
+        "task.progress"
+      ],
+      "language": "en",
+      "license": "fair-use",
+      "sound_count": 18,
+      "total_size_bytes": 6714336,
+      "source_repo": "SeanROlszewski/orb-peonping",
+      "source_ref": "v1.0.1",
+      "source_path": ".",
+      "manifest_sha256": "e5659f17fd3cb3f6ef7344113dc8341def14be75a4ab040c38fceff13b70036c",
+      "tags": [
+        "orb",
+        "worldcoin",
+        "tools-for-humanity",
+        "biometric",
+        "sci-fi"
+      ],
+      "preview_sounds": [
+        "sound_bootup.wav",
+        "sound_iris_scan_success.wav"
+      ],
+      "added": "2026-04-17",
+      "updated": "2026-04-17"
+    },
+    {
       "name": "orisa",
       "display_name": "Overwatch - Orisa",
       "version": "1.0.0",


### PR DESCRIPTION
Howdy! I work at Tools for Humanity and have been using `peon-ping` daily for quite some time. We have hardware (The Orb) that plays various sounds as part of it's user experience. I wanted to make a `peon-ping` pack that lets developers use those same sounds in their day-to-day work. Let me know if any changes are needed ahead of merging this. I've tested it locally and it sounds great. 

## Summary

Adds `orb-ping` to the registry.

- **Pack**: Orb Ping v1.0.1
- **Source**: [SeanROlszewski/orb-peonping@v1.0.1](https://github.com/SeanROlszewski/orb-peonping/releases/tag/v1.0.1)
- **Sounds**: 18 clips from Tools for Humanity's Orb
- **Categories**: session.start, session.end, task.complete, task.error, task.progress, input.required
- **License**: fair-use
- **Trust tier**: community

## Validation

- `index.json` parses as valid JSON
- Entry validates against `schema/registry-v1.schema.json` (`$defs/pack`)
- Inserted alphabetically between `op-kurtlar-vadisi` and `orisa`
- Manifest SHA256 matches the tagged release

## Test plan

- [x] JSON syntax valid
- [x] Entry validates against pack schema
- [ ] CI validation passes
- [ ] Pack installs via `peon packs install orb-ping`