### PR TITLE
Add sc_probe (Protoss Probe) sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -8761,6 +8761,42 @@
       "updated": "2026-02-26"
     },
     {
+      "name": "sc_probe",
+      "display_name": "Protoss Probe (StarCraft II)",
+      "version": "1.0.0",
+      "description": "Protoss Probe sound pack from StarCraft II",
+      "author": {
+        "name": "dmurai",
+        "github": "dmurai"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "session.end",
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 19,
+      "total_size_bytes": 337029,
+      "source_repo": "dmurai/sc_probe",
+      "source_ref": "main",
+      "source_path": ".",
+      "manifest_sha256": "aa79a7296c578a7795500887ae88501cb7657c068020ab236aca562ddfac5ff3",
+      "tags": [
+        "gaming",
+        "starcraft",
+        "rts",
+        "blizzard"
+      ],
+      "added": "2026-04-18",
+      "updated": "2026-04-18"
+    },
+    {
       "name": "sc_raynor",
       "display_name": "StarCraft Raynor",
       "version": "1.0.0",

--- a/index.json
+++ b/index.json
@@ -8772,6 +8772,7 @@
       "trust_tier": "community",
       "categories": [
         "input.required",
+        "resource.limit",
         "session.end",
         "session.start",
         "task.acknowledge",
@@ -8781,12 +8782,12 @@
       ],
       "language": "en",
       "license": "CC-BY-NC-4.0",
-      "sound_count": 19,
+      "sound_count": 20,
       "total_size_bytes": 337029,
       "source_repo": "dmurai/sc_probe",
       "source_ref": "main",
       "source_path": ".",
-      "manifest_sha256": "aa79a7296c578a7795500887ae88501cb7657c068020ab236aca562ddfac5ff3",
+      "manifest_sha256": "3ef59738bcfa1499826c7ee2aa2ccdd64c24a25ea996b59c47cc93f839b28974",
       "tags": [
         "gaming",
         "starcraft",


### PR DESCRIPTION
## Summary
- Add new Protoss Probe (StarCraft II) sound pack
- 19 sounds across 7 categories
- Source: dmurai/sc_probe

## Test plan
- [ ] Verify manifest loads from `dmurai/sc_probe` at `main`
- [ ] Confirm all 19 sounds play correctly on the site

🤖 Generated with [Claude Code](https://claude.com/claude-code)