### PR TITLE
Add sts2_shopkeeper (Slay the Spire 2 Shop Keeper)

### DIFF
--- a/index.json
+++ b/index.json
@@ -9946,6 +9946,47 @@
       "updated": "2026-04-08"
     },
     {
+      "name": "sts2_shopkeeper",
+      "display_name": "Slay the Spire 2 Shop Keeper",
+      "version": "1.0.0",
+      "description": "Merchant and Reverse Merchant voice lines from Slay the Spire 2 — shop keeper grunts, thanks, and disappointed grumbles",
+      "author": {
+        "name": "flavono123",
+        "github": "flavono123"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 27,
+      "total_size_bytes": 9073188,
+      "source_repo": "flavono123/sts2-shopkeeper-peon",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "189e0323b3e6f73387e3ce2e199d75cdf9eaaf66533e6524a172525125a5cad2",
+      "tags": [
+        "gaming",
+        "slay-the-spire",
+        "mega-crit",
+        "roguelike",
+        "deckbuilder"
+      ],
+      "preview_sounds": [
+        "merchant_welcome_1.wav",
+        "merchant_disappointment_1.wav"
+      ],
+      "added": "2026-04-22",
+      "updated": "2026-04-22"
+    },
+    {
       "name": "sultan",
       "display_name": "The Sultan (Stronghold Crusader)",
       "version": "1.2.1",


### PR DESCRIPTION
## Summary

Adds a new community-tier pack: `sts2_shopkeeper` — Merchant and Reverse Merchant voice lines from *Slay the Spire 2* (Mega Crit, 2026).

- **27 VO clips** across 7 CESP categories (all required + `user.spam`)
- **Repo:** [flavono123/sts2-shopkeeper-peon @ v1.0.0](https://github.com/flavono123/sts2-shopkeeper-peon/releases/tag/v1.0.0)
- **Size:** 8.7 MB (under the 50 MB limit)
- **License:** CC-BY-NC-4.0 — fan-made, non-commercial, audio remains Mega Crit property

## Category mapping

| CESP event         | Source VO event (`sfx.bank`)          | Clips |
|--------------------|---------------------------------------|------:|
| `session.start`    | `merchant_welcome`                    |     4 |
| `task.acknowledge` | `merchant_laughter`                   |     2 |
| `task.complete`    | `merchant_thank_yous`                 |     3 |
| `task.error`       | `merchant_dissapointment` *(sic)*     |     3 |
| `input.required`   | `merchant_passive`                    |     2 |
| `resource.limit`   | `reverse_merchant_hurt_sad` + `_die`  |     7 |
| `user.spam`        | `reverse_merchant_hehe`               |     6 |

## Notes

- Audio extracted from the game PCK → `sfx.bank` (FMOD Studio) using [GDRE Tools](https://github.com/GDRETools/gdsdecomp) + [vgmstream](https://github.com/vgmstream/vgmstream)
- Insertion point: alphabetical between `stronghold-peasant-es` and `sultan`
- `total_packs` top-level field left untouched (was already stale at 295 in upstream)