### PR TITLE
Add sts2_regent (Slay the Spire 2 Regent)

### DIFF
--- a/index.json
+++ b/index.json
@@ -9946,6 +9946,49 @@
       "updated": "2026-04-08"
     },
     {
+      "name": "sts2_regent",
+      "display_name": "Slay the Spire 2 Regent",
+      "version": "1.0.1",
+      "description": "Regent voice lines from Slay the Spire 2 — a playable character voiced by Mark Ota, with greetings, impatient quips, triumphant cheers, and hurt cries across three intensity levels",
+      "author": {
+        "name": "flavono123",
+        "github": "flavono123"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 70,
+      "total_size_bytes": 13458124,
+      "source_repo": "flavono123/sts2-regent-peon",
+      "source_ref": "v1.0.1",
+      "source_path": ".",
+      "manifest_sha256": "bae40409e9d6ef3089c47710331bd89cc894a03e41467b0702cb8aeed97732ce",
+      "tags": [
+        "gaming",
+        "slay-the-spire",
+        "mega-crit",
+        "roguelike",
+        "deckbuilder",
+        "regent",
+        "playable-character"
+      ],
+      "preview_sounds": [
+        "regent_greeting_1.wav",
+        "regent_impatient_1.wav"
+      ],
+      "added": "2026-04-24",
+      "updated": "2026-04-24"
+    },
+    {
       "name": "sts2_shopkeeper",
       "display_name": "Slay the Spire 2 Shop Keeper",
       "version": "1.0.0",


### PR DESCRIPTION
## Summary

Adds a new community-tier pack: `sts2_regent` — Slay the Spire 2 Regent from *Slay the Spire 2* (Mega Crit, 2026).

- **70 VO clips** across 7 CESP categories (all required + `user.spam`)
- **Repo:** [flavono123/sts2-regent-peon @ v1.0.0](https://github.com/flavono123/sts2-regent-peon/releases/tag/v1.0.0)
- **License:** CC-BY-NC-4.0 — fan-made, non-commercial, audio remains Mega Crit property
- **Extraction pipeline:** Same as my earlier [`sts2_shopkeeper`](https://github.com/PeonPing/registry/pull/266) PR — GDRE Tools + vgmstream-cli on `sfx.bank` (FMOD FSB5)

Part of a four-pack batch (`sts2_ancients`, `sts2_regent`, `sts2_the_kin`, `sts2_twotailrats`) released together; each is a separate PR to keep them independently reviewable.