### PR TITLE
Add sts2_the_kin (Slay the Spire 2 The Kin)

### DIFF
--- a/index.json
+++ b/index.json
@@ -9987,6 +9987,49 @@
       "updated": "2026-04-22"
     },
     {
+      "name": "sts2_the_kin",
+      "display_name": "Slay the Spire 2 The Kin",
+      "version": "1.0.0",
+      "description": "The Kin (kin_minion + kin_leader) boss voice lines from Slay the Spire 2 — cult chants, rallies, and death cries",
+      "author": {
+        "name": "flavono123",
+        "github": "flavono123"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 43,
+      "total_size_bytes": 10818560,
+      "source_repo": "flavono123/sts2-the-kin-peon",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "9732be7f65c11a60f76ca728086894936d6fc60a8d2b5c1810fd17c4a3f8f304",
+      "tags": [
+        "gaming",
+        "slay-the-spire",
+        "mega-crit",
+        "roguelike",
+        "deckbuilder",
+        "the-kin",
+        "boss"
+      ],
+      "preview_sounds": [
+        "kin_leader_rally_1.wav",
+        "kin_minion_hurt_1.wav"
+      ],
+      "added": "2026-04-24",
+      "updated": "2026-04-24"
+    },
+    {
       "name": "sultan",
       "display_name": "The Sultan (Stronghold Crusader)",
       "version": "1.2.1",


### PR DESCRIPTION
## Summary

Adds a new community-tier pack: `sts2_the_kin` — Slay the Spire 2 The Kin from *Slay the Spire 2* (Mega Crit, 2026).

- **43 VO clips** across 7 CESP categories (all required + `user.spam`)
- **Repo:** [flavono123/sts2-the-kin-peon @ v1.0.0](https://github.com/flavono123/sts2-the-kin-peon/releases/tag/v1.0.0)
- **License:** CC-BY-NC-4.0 — fan-made, non-commercial, audio remains Mega Crit property
- **Extraction pipeline:** Same as my earlier [`sts2_shopkeeper`](https://github.com/PeonPing/registry/pull/266) PR — GDRE Tools + vgmstream-cli on `sfx.bank` (FMOD FSB5)

Part of a four-pack batch (`sts2_ancients`, `sts2_regent`, `sts2_the_kin`, `sts2_twotailrats`) released together; each is a separate PR to keep them independently reviewable.