### PR TITLE
Add sts2_twotailrats (Slay the Spire 2 Two-Tailed Rats)

### DIFF
--- a/index.json
+++ b/index.json
@@ -10030,6 +10030,48 @@
       "updated": "2026-04-24"
     },
     {
+      "name": "sts2_twotailrats",
+      "display_name": "Slay the Spire 2 Two-Tailed Rats",
+      "version": "1.0.1",
+      "description": "Two-Tailed Rats monster voice lines from Slay the Spire 2 — hurt yelps, attack snarls, and death squeaks voiced by Mars Orach",
+      "author": {
+        "name": "flavono123",
+        "github": "flavono123"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 37,
+      "total_size_bytes": 5919430,
+      "source_repo": "flavono123/sts2-twotailrats-peon",
+      "source_ref": "v1.0.1",
+      "source_path": ".",
+      "manifest_sha256": "e28724a20aa4d782a7fdb3dc632fc9ede25d9fbfebbd4c7c160e5367d5ff97cf",
+      "tags": [
+        "gaming",
+        "slay-the-spire",
+        "mega-crit",
+        "roguelike",
+        "deckbuilder",
+        "monster"
+      ],
+      "preview_sounds": [
+        "twotailrats_summon_1.wav",
+        "twotailrats_hurt_1.wav"
+      ],
+      "added": "2026-04-24",
+      "updated": "2026-04-24"
+    },
+    {
       "name": "sultan",
       "display_name": "The Sultan (Stronghold Crusader)",
       "version": "1.2.1",


### PR DESCRIPTION
## Summary

Adds a new community-tier pack: `sts2_twotailrats` — Slay the Spire 2 Two-Tailed Rats from *Slay the Spire 2* (Mega Crit, 2026).

- **37 VO clips** across 7 CESP categories (all required + `user.spam`)
- **Repo:** [flavono123/sts2-twotailrats-peon @ v1.0.0](https://github.com/flavono123/sts2-twotailrats-peon/releases/tag/v1.0.0)
- **License:** CC-BY-NC-4.0 — fan-made, non-commercial, audio remains Mega Crit property
- **Extraction pipeline:** Same as my earlier [`sts2_shopkeeper`](https://github.com/PeonPing/registry/pull/266) PR — GDRE Tools + vgmstream-cli on `sfx.bank` (FMOD FSB5)

Part of a four-pack batch (`sts2_ancients`, `sts2_regent`, `sts2_the_kin`, `sts2_twotailrats`) released together; each is a separate PR to keep them independently reviewable.