### PR TITLE
Update sts2_the_kin to v1.0.1 (trim trailing silence)

### DIFF
--- a/index.json
+++ b/index.json
@@ -9989,7 +9989,7 @@
     {
       "name": "sts2_the_kin",
       "display_name": "Slay the Spire 2 The Kin",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "The Kin (kin_minion + kin_leader) boss voice lines from Slay the Spire 2 — cult chants, rallies, and death cries",
       "author": {
         "name": "flavono123",
@@ -10008,11 +10008,11 @@
       "language": "en",
       "license": "CC-BY-NC-4.0",
       "sound_count": 43,
-      "total_size_bytes": 10818560,
+      "total_size_bytes": 7080230,
       "source_repo": "flavono123/sts2-the-kin-peon",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": ".",
-      "manifest_sha256": "9732be7f65c11a60f76ca728086894936d6fc60a8d2b5c1810fd17c4a3f8f304",
+      "manifest_sha256": "c363791ade2ec65f87d4e62a458383f6a4d26d0d6dddcde6a8ccc324f1db8f98",
       "tags": [
         "gaming",
         "slay-the-spire",


### PR DESCRIPTION
## Summary

Bumps existing `sts2_the_kin` entry from v1.0.0 → v1.0.1.

The v1.0.0 release shipped with significant trailing dead air on every clip (averaged ~0.86s on this pack). Trimmed via:

```
ffmpeg -af silenceremove=stop_periods=-1:stop_duration=0.1:stop_threshold=-35dB
```

The threshold matches `registry/.github/scripts/quality-check.py`'s `SILENCE_THRESHOLD_DB = -35`, so trimmed output should pass the audio-quality gate cleanly.

**Updated fields:** `version`, `source_ref`, `manifest_sha256`, `total_size_bytes`, `updated`. Tags / preview_sounds / description / categories all unchanged.

**Source:** [flavono123/sts2-the-kin-peon @ v1.0.1](https://github.com/flavono123/sts2-the-kin-peon/releases/tag/v1.0.1)