### PR TITLE
Update alan-rickman to v1.1.0

### DIFF
--- a/index.json
+++ b/index.json
@@ -361,7 +361,7 @@
     {
       "name": "alan-rickman",
       "display_name": "Alan Rickman",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "description": "Claudette notification sounds, voiced in the manner of the late Alan Rickman. Slow. Deliberate. Faintly amused.",
       "author": {
         "name": "Utensils",
@@ -378,12 +378,12 @@
       ],
       "language": "en",
       "license": "CC-BY-4.0",
-      "sound_count": 24,
-      "total_size_bytes": 779285,
+      "sound_count": 60,
+      "total_size_bytes": 1964096,
       "source_repo": "utensils/openpeon-alan-rickman-soundpack",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.1.0",
       "source_path": ".",
-      "manifest_sha256": "7fff4547690203a0f5c0d3907a1279ea126b52b71435e42536db58b697e1d7bd",
+      "manifest_sha256": "3494efdc804c627bb8fdd23bca7cf006cbcc7cc69eff9412969fd5cd57918e7b",
       "tags": [
         "tts",
         "ai-voice",
@@ -396,7 +396,7 @@
         "task_complete_01.mp3"
       ],
       "added": "2026-04-29",
-      "updated": "2026-04-30"
+      "updated": "2026-05-01"
     },
     {
       "name": "ana",


### PR DESCRIPTION
Each CESP category expanded from 4 to 10 phrase variants (36 new sounds total). sound_count 24 → 60, manifest hash and source_ref refreshed for the v1.1.0 release tag.