### PR TITLE
Add sc2_scv community pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -8570,6 +8570,49 @@
       "updated": "2026-02-20"
     },
     {
+      "name": "sc2_scv",
+      "display_name": "StarCraft II SCV",
+      "version": "1.0.0",
+      "description": "StarCraft II SCV sound pack \u2014 44 sounds across all 7 CESP categories. Audio recorded from StarCraft II by Blizzard Entertainment.",
+      "author": {
+        "name": "emmanuel",
+        "github": "MrDoomBringer"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "session.start",
+        "task.acknowledge",
+        "task.complete",
+        "task.error",
+        "input.required",
+        "resource.limit",
+        "user.spam"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 44,
+      "total_size_bytes": 1329668,
+      "source_repo": "MrDoomBringer/openpeon-sc2-scv",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "24bda0fa13dda8bd42d9e7aefe7eb44a70e809cc4ba61e8123827de9a5c39423",
+      "tags": [
+        "gaming",
+        "starcraft",
+        "starcraft2",
+        "sc2",
+        "blizzard",
+        "rts",
+        "terran"
+      ],
+      "preview_sounds": [
+        "SCVReady1.mp3",
+        "SCVReady2.mp3"
+      ],
+      "added": "2026-05-03",
+      "updated": "2026-05-03"
+    },
+    {
       "name": "sc2_scv_kr",
       "display_name": "\uac74\uc124\ub85c\ubd07 SCV (StarCraft II, \ud55c\uad6d\uc5b4)",
       "version": "1.0.0",
@@ -12940,5 +12983,5 @@
       "updated": "2026-04-17"
     }
   ],
-  "total_packs": 321
+  "total_packs": 322
 }

--- a/index.json
+++ b/index.json
@@ -8571,8 +8571,8 @@
     },
     {
       "name": "sc2_scv",
-      "display_name": "StarCraft II SCV",
-      "version": "1.0.0",
+      "display_name": "Emm's StarCraft II SCV",
+      "version": "1.0.1",
       "description": "StarCraft II SCV sound pack \u2014 44 sounds across all 7 CESP categories. Audio recorded from StarCraft II by Blizzard Entertainment.",
       "author": {
         "name": "emmanuel",
@@ -8593,9 +8593,9 @@
       "sound_count": 44,
       "total_size_bytes": 1329668,
       "source_repo": "MrDoomBringer/openpeon-sc2-scv",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": ".",
-      "manifest_sha256": "24bda0fa13dda8bd42d9e7aefe7eb44a70e809cc4ba61e8123827de9a5c39423",
+      "manifest_sha256": "468fbef3a9ba37601bc7a82cef536b8fd4dd7e5a7106bfd920f6f716ba48a62c",
       "tags": [
         "gaming",
         "starcraft",


### PR DESCRIPTION
## Summary

Adds a new community sound pack: **`sc2_scv`** — StarCraft II SCV voice lines.

- **Source repo:** https://github.com/MrDoomBringer/openpeon-sc2-scv
- **Release:** [v1.0.0](https://github.com/MrDoomBringer/openpeon-sc2-scv/releases/tag/v1.0.0)
- **44 sounds** across all 7 CESP categories (session.start, task.acknowledge, task.complete, task.error, input.required, resource.limit, user.spam)
- **Language:** en
- **License:** CC-BY-NC-4.0 (non-commercial fan use; audio recorded from StarCraft II by Blizzard Entertainment)
- **Trust tier:** community
- **Total size:** 1.27 MB

Inserted alphabetically between `sc2_carrier` and `sc2_scv_kr`. `total_packs` bumped from 321 → 322.

Note: distinct from the existing `sc_scv` (official, harrymunro, StarCraft 1, 19 sounds) — this one is StarCraft II-specific with a much expanded set.

## Validation

- New entry validates against `schema/registry-v1.schema.json` (the `pack` definition).
- Manifest SHA256 in entry matches `openpeon.json` in the source repo.