### PR TITLE
Bump tywin-lannister to v1.1.1

### DIFF
--- a/index.json
+++ b/index.json
@@ -11700,8 +11700,8 @@
     {
       "name": "tywin-lannister",
       "display_name": "Tywin Lannister",
-      "version": "1.0.3",
-      "description": "Sound pack featuring Tywin Lannister, Lord of Casterly Rock and Hand of the King.",
+      "version": "1.1.1",
+      "description": "Sound pack featuring Tywin Lannister, Lord of Casterly Rock and Hand of the King. Some voice lines are AI-generated.",
       "author": {
         "name": "dmltdev",
         "github": "dmltdev"
@@ -11709,18 +11709,21 @@
       "trust_tier": "community",
       "categories": [
         "input.required",
+        "resource.limit",
         "session.start",
+        "task.acknowledge",
         "task.complete",
-        "task.error"
+        "task.error",
+        "user.spam"
       ],
       "language": "en",
       "license": "CC-BY-NC-4.0",
-      "sound_count": 20,
-      "total_size_bytes": 1708830,
+      "sound_count": 32,
+      "total_size_bytes": 2414746,
       "source_repo": "dmltdev/openpeon-tywin-lannister",
-      "source_ref": "v1.0.3",
+      "source_ref": "v1.1.1",
       "source_path": ".",
-      "manifest_sha256": "d616ba4d2e7a2308def5c6e54af9f294e5ac4afafe9646e871c4c6cf135eb502",
+      "manifest_sha256": "a1db2b308c042c52b6c2443de668ecc3f73f780afafe7d04be2bd699d6e7a6d2",
       "tags": [
         "gaming",
         "game-of-thrones",
@@ -11731,7 +11734,7 @@
         "try-harder.mp3"
       ],
       "added": "2026-05-09",
-      "updated": "2026-05-09"
+      "updated": "2026-05-10"
     },
     {
       "name": "vendetta",

--- a/index.json
+++ b/index.json
@@ -11700,7 +11700,7 @@
     {
       "name": "tywin-lannister",
       "display_name": "Tywin Lannister",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "description": "Sound pack featuring Tywin Lannister, Lord of Casterly Rock and Hand of the King.",
       "author": {
         "name": "dmltdev",
@@ -11718,9 +11718,9 @@
       "sound_count": 18,
       "total_size_bytes": 1570209,
       "source_repo": "dmltdev/openpeon-tywin-lannister",
-      "source_ref": "v1.0.0",
+      "source_ref": "v1.0.1",
       "source_path": ".",
-      "manifest_sha256": "12b86b963b50d333e36059881bff41d39272b23a56a6cd40c44de21f9afa89d9",
+      "manifest_sha256": "25a35e2eadc59da5dd8b85378f76b2bfe092485da7828b5d9f24bd57c8302df8",
       "tags": [
         "gaming",
         "game-of-thrones",
@@ -11730,8 +11730,8 @@
         "any-man-who-must-say-i-am-the-king-is-no-true-king.mp3",
         "try-harder.mp3"
       ],
-      "added": "2026-05-08",
-      "updated": "2026-05-08"
+      "added": "2026-05-09",
+      "updated": "2026-05-09"
     },
     {
       "name": "vendetta",

--- a/index.json
+++ b/index.json
@@ -11698,6 +11698,42 @@
       "updated": "2026-03-12"
     },
     {
+      "name": "tywin-lannister",
+      "display_name": "Tywin Lannister",
+      "version": "1.0.0",
+      "description": "Sound pack featuring Tywin Lannister, Lord of Casterly Rock and Hand of the King.",
+      "author": {
+        "name": "dmltdev",
+        "github": "dmltdev"
+      },
+      "trust_tier": "community",
+      "categories": [
+        "input.required",
+        "session.start",
+        "task.complete",
+        "task.error"
+      ],
+      "language": "en",
+      "license": "CC-BY-NC-4.0",
+      "sound_count": 18,
+      "total_size_bytes": 1570209,
+      "source_repo": "dmltdev/openpeon-tywin-lannister",
+      "source_ref": "v1.0.0",
+      "source_path": ".",
+      "manifest_sha256": "12b86b963b50d333e36059881bff41d39272b23a56a6cd40c44de21f9afa89d9",
+      "tags": [
+        "gaming",
+        "game-of-thrones",
+        "tv"
+      ],
+      "preview_sounds": [
+        "any-man-who-must-say-i-am-the-king-is-no-true-king.mp3",
+        "try-harder.mp3"
+      ],
+      "added": "2026-05-08",
+      "updated": "2026-05-08"
+    },
+    {
       "name": "vendetta",
       "display_name": "Overwatch - Vendetta",
       "version": "1.0.0",

--- a/index.json
+++ b/index.json
@@ -11700,7 +11700,7 @@
     {
       "name": "tywin-lannister",
       "display_name": "Tywin Lannister",
-      "version": "1.0.1",
+      "version": "1.0.3",
       "description": "Sound pack featuring Tywin Lannister, Lord of Casterly Rock and Hand of the King.",
       "author": {
         "name": "dmltdev",
@@ -11715,12 +11715,12 @@
       ],
       "language": "en",
       "license": "CC-BY-NC-4.0",
-      "sound_count": 18,
-      "total_size_bytes": 1570209,
+      "sound_count": 20,
+      "total_size_bytes": 1708830,
       "source_repo": "dmltdev/openpeon-tywin-lannister",
-      "source_ref": "v1.0.1",
+      "source_ref": "v1.0.3",
       "source_path": ".",
-      "manifest_sha256": "25a35e2eadc59da5dd8b85378f76b2bfe092485da7828b5d9f24bd57c8302df8",
+      "manifest_sha256": "d616ba4d2e7a2308def5c6e54af9f294e5ac4afafe9646e871c4c6cf135eb502",
       "tags": [
         "gaming",
         "game-of-thrones",


### PR DESCRIPTION
## Summary

  - Bumps `tywin-lannister` from v1.0.3 to v1.1.1
  - Adds 12 AI-generated voice lines (prefixed `ai-*`)
  - Expands categories: `resource.limit`, `task.acknowledge`, `user.spam`
  - Removes duplicate sounds (each sound now belongs to exactly one category)
  - Sound count: 20 -> 32