### PR TITLE
Update minimal-dings to v1.0.1

### DIFF
--- a/index.json
+++ b/index.json
@@ -5823,7 +5823,7 @@
         {
             "name": "minimal-dings",
             "display_name": "Minimal Dings",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "description": "Minimal aircraft-cabin chimes. Soft bell tones you can learn to read at a glance and never tire of hearing.",
             "author": {
                 "name": "iain",
@@ -5844,11 +5844,11 @@
             "language": "en",
             "license": "CC0-1.0",
             "sound_count": 9,
-            "total_size_bytes": 1210498,
+            "total_size_bytes": 1170808,
             "source_repo": "iain/minimal-dings",
-            "source_ref": "v1.0.0",
+            "source_ref": "v1.0.1",
             "source_path": "minimal-dings",
-            "manifest_sha256": "8607736369d7c4daf73687de4d685527618c0d0d71fe80fa03e502c2d60679ba",
+            "manifest_sha256": "b90af02992a9974db5ca324da5e4849f94d015e954d45358000a472ba9db64d5",
             "tags": [
                 "minimal",
                 "chimes",


### PR DESCRIPTION
Follow-up to #307 (merged just before this revision landed).

Bumps **minimal-dings** to v1.0.1: trims the trailing near-silence on `error.wav` and `limit.wav` so the pack clears the quality checker's dead-air warnings and now scores **GOLD** (0 blocks, 0 warnings). No audible change to the sounds — only the deepest sub-35 dB tail was shortened.

Updates `version`, `source_ref` (tag `v1.0.1`), `manifest_sha256`, and `total_size_bytes`.