### PR TITLE
Add anran sound pack (Overwatch)

### DIFF
--- a/index.json
+++ b/index.json
@@ -606,6 +606,50 @@
             "updated": "2026-02-25"
         },
         {
+            "name": "anran",
+            "display_name": "Overwatch - Anran",
+            "version": "1.0.0",
+            "description": "Anran voice lines from Overwatch -- the fiery martial artist who'll burn brightest",
+            "author": {
+                "name": "heron--",
+                "github": "heron--"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 44,
+            "total_size_bytes": 477888,
+            "source_repo": "heron--/overwatch-peon-pings",
+            "source_ref": "v1.1.0",
+            "source_path": "anran",
+            "manifest_sha256": "27b443c15d8f5f97058940c4d5e1292eb9b63a083a00eea18e670e15a55a584e",
+            "tags": [
+                "gaming",
+                "overwatch",
+                "blizzard",
+                "fps",
+                "fire",
+                "martial-arts"
+            ],
+            "preview_sounds": [
+                "session_start_1.mp3",
+                "task_complete_1.mp3"
+            ],
+            "added": "2026-05-21",
+            "updated": "2026-05-21"
+        },
+        {
             "name": "aod",
             "display_name": "Army of Darkness",
             "version": "1.0.0",


### PR DESCRIPTION
## New Pack: Anran (Overwatch)

**Source repo:** https://github.com/heron--/overwatch-peon-pings
**Path:** `anran/`
**Tag:** v1.1.0

44 voice lines across 9 CESP categories from Overwatch's Anran, the fiery martial artist. Includes English and Mandarin Chinese voice lines.

### Categories
| Category | Count | Sample |
|---|---|---|
| `session.start` | 5 | "Let's bring the heat!", "The fire in my heart will never burn out." |
| `task.acknowledge` | 5 | "Sounds good.", "Understood.", "You got it." |
| `task.complete` | 5 | "Burned to a crisp.", "I always exceed expectations!" |
| `task.error` | 5 | "Dammit.", "Nope. Let my form slip..." |
| `input.required` | 5 | "Help me.", "Group up with me!" |
| `resource.limit` | 5 | "We're running out of time. Move it!" |
| `user.spam` | 5 | "That's all you've got?", "Do better." |
| `session.end` | 4 | "Bye.", "Later!", "Zài jiàn." |
| `task.progress` | 5 | "One more time.", "I'll get up no matter how many times they knock me down." |

### Checklist
- [x] Public source repo
- [x] Valid `openpeon.json` manifest (CESP v1.0)
- [x] Audio files are `.mp3`, all under 1 MB each
- [x] Total pack size under 50 MB (478 KB)
- [x] Release tagged `v1.1.0`
- [x] Entry in alphabetical order in `index.json`
- [x] `manifest_sha256` computed