### PR TITLE
Add yennefer pack (community)

### DIFF
--- a/index.json
+++ b/index.json
@@ -2464,9 +2464,19 @@
             "display_name": "Dota 2 Sounds",
             "version": "1.0.0",
             "description": "Item and rune sounds from Dota 2. BKB for victories, silenced for errors, mana for limits.",
-            "author": { "name": "darkocejkov", "github": "darkocejkov" },
+            "author": {
+                "name": "darkocejkov",
+                "github": "darkocejkov"
+            },
             "trust_tier": "community",
-            "categories": ["session.start", "task.acknowledge", "task.complete", "task.error", "input.required", "resource.limit"],
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
             "language": "en",
             "license": "CC-BY-NC-4.0",
             "sound_count": 28,
@@ -2475,8 +2485,15 @@
             "source_ref": "v1.0.0",
             "source_path": ".",
             "manifest_sha256": "d96b3d352853fd7f706cbca51c78280716038c14fe6bc2070bec5950e6ec5e7b",
-            "tags": ["gaming", "dota2"],
-            "preview_sounds": ["reincarnate.wav", "hand_of_midas.wav", "silenced.wav"],
+            "tags": [
+                "gaming",
+                "dota2"
+            ],
+            "preview_sounds": [
+                "reincarnate.wav",
+                "hand_of_midas.wav",
+                "silenced.wav"
+            ],
             "added": "2026-05-26",
             "updated": "2026-05-26"
         },
@@ -4583,9 +4600,19 @@
             "display_name": "IO (Dota 2)",
             "version": "1.0.0",
             "description": "Sound pack featuring IO the Wisp from Dota 2. Tether up.",
-            "author": { "name": "darkocejkov", "github": "darkocejkov" },
+            "author": {
+                "name": "darkocejkov",
+                "github": "darkocejkov"
+            },
             "trust_tier": "community",
-            "categories": ["session.start", "task.acknowledge", "task.complete", "task.error", "input.required", "resource.limit"],
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit"
+            ],
             "language": "en",
             "license": "CC-BY-NC-4.0",
             "sound_count": 12,
@@ -4594,8 +4621,14 @@
             "source_ref": "v1.0.0",
             "source_path": ".",
             "manifest_sha256": "22dbaf2ba56b7e280f28811e0d28a89c05582f4123833f11b28f8e03439c9d24",
-            "tags": ["gaming", "dota2"],
-            "preview_sounds": ["win.wav", "spawn_respawn.wav"],
+            "tags": [
+                "gaming",
+                "dota2"
+            ],
+            "preview_sounds": [
+                "win.wav",
+                "spawn_respawn.wav"
+            ],
             "added": "2026-05-26",
             "updated": "2026-05-26"
         },
@@ -13065,6 +13098,49 @@
             "updated": "2026-03-11"
         },
         {
+            "name": "yennefer",
+            "display_name": "Yennefer of Vengerberg",
+            "version": "1.0.0",
+            "description": "Claude Code notification sounds voiced as Yennefer (The Witcher). Composed British sorceress — dry, commanding, faintly amused. ChatterboxTTS expressive base, RVC voice conversion.",
+            "author": {
+                "name": "John Rebellion",
+                "github": "JohnRebellion"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 20,
+            "total_size_bytes": 293426,
+            "source_repo": "JohnRebellion/openpeon-yennefer-soundpack",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "dfbf0e526386ee28ff45bdca94e4fc9275568c2e88d9c282f97366b4e8a7549a",
+            "tags": [
+                "tts",
+                "ai-voice",
+                "yennefer",
+                "witcher",
+                "rvc",
+                "british",
+                "claude-code"
+            ],
+            "preview_sounds": [
+                "start_begin.mp3",
+                "done_clean.mp3"
+            ],
+            "added": "2026-06-07",
+            "updated": "2026-06-07"
+        },
+        {
             "name": "zarya",
             "display_name": "Overwatch - Zarya",
             "version": "1.0.0",
@@ -13351,5 +13427,5 @@
             "updated": "2026-04-17"
         }
     ],
-    "total_packs": 323
+    "total_packs": 333
 }


### PR DESCRIPTION
## Adding pack: yennefer (Yennefer of Vengerberg)

**Source repo:** https://github.com/JohnRebellion/openpeon-yennefer-soundpack
**Tag:** v1.0.0
**Trust tier:** community
**License:** CC-BY-NC-4.0 (fan-made, non-commercial)
**Manifest sha256:** `dfbf0e526386ee28ff45bdca94e4fc9275568c2e88d9c282f97366b4e8a7549a`
**Sounds:** 20 mp3, 287 KB total
**Categories:** session.start, task.acknowledge, task.complete, task.error, input.required, resource.limit, user.spam

### Voice + generation
- Character: **Yennefer of Vengerberg** (The Witcher series) — composed British sorceress
- Pipeline: **ChatterboxTTS** (per-category exaggeration 0.45–0.85, deliberate punctuation for cadence) → **RVC voice conversion** to a community Yennefer model
- All sounds intent-mapped per category (e.g. `task.error` → "Bloody... hell.")

### Checklist
- [x] Pack repo public + tagged v1.0.0
- [x] Manifest sha256 matches openpeon.json in tagged release
- [x] All sounds .mp3, under 1 MB each, 287 KB total
- [x] Alphabetical insertion (between yasuo-pack and zarya)
- [x] Validated against schema/registry-v1.schema.json (pack entry)

Fan-made tribute; no affiliation with CD Projekt Red.