### PR TITLE
feat(quality): pack-level loudness scoring, tier persistence, and catalog backfill

### DIFF
--- a/.github/scripts/backfill-quality.py
+++ b/.github/scripts/backfill-quality.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""backfill-quality.py — one-time grade of the whole catalog into index.json.
+
+Grades every listed pack with the same pipeline the gate and the persist job
+use, maps each verdict to the quality enum, and writes the tiers into index.json
+in a single serialization-preserving pass (reuses the U4 write-back). It is
+non-destructive: entries are only updated, never removed. A pack that grades
+below the bar is recorded as 'flagged' and listed in the summary for maintainer
+review, not delisted.
+
+Intended to run as a workflow_dispatch job that writes to a branch and opens a
+PR, so a maintainer reviews the catalog-wide change before it lands on main.
+
+Resume: by default, packs already graded (quality is not 'unreviewed') are
+skipped, so a re-run converges. --force-regrade re-touches every pack, for use
+after a threshold change when the default skip would grade nothing.
+
+Usage:
+  python3 backfill-quality.py --index index.json [--workers 8] [--force-regrade]
+                              [--limit N] [--packs a,b] [--summary-json FILE]
+
+Dependencies: Python 3.8+, ffmpeg/ffprobe. No pip packages.
+"""
+
+import argparse
+import importlib.util
+import json
+import shutil
+import sys
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+# Load the checker module by path and reuse its grading + write-back helpers.
+_CHECKER_PATH = Path(__file__).resolve().parent / "quality-check.py"
+_spec = importlib.util.spec_from_file_location("quality_check", _CHECKER_PATH)
+qc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(qc)
+
+DEFAULT_QUALITY = "unreviewed"
+
+
+def select_targets(packs, force_regrade=False, limit=None, names=None):
+    """Choose which entries to grade.
+
+    Without --force-regrade, already-graded packs (quality not 'unreviewed') are
+    skipped so a re-run converges. --packs and --limit scope smaller runs and are
+    applied before the resume skip.
+    """
+    targets = packs
+    if names:
+        by_name = {p.get("name"): p for p in packs}
+        targets = [by_name[n] for n in names if n in by_name]
+    elif limit:
+        targets = packs[:limit]
+
+    if not force_regrade:
+        targets = [p for p in targets if p.get("quality", DEFAULT_QUALITY) == DEFAULT_QUALITY]
+    return targets
+
+
+def grade_entry(entry):
+    """Download and grade one pack. Returns a result dict, never raises."""
+    name = entry.get("name", "?")
+    dest = tempfile.mkdtemp(prefix=f"backfill-{name}-")
+    try:
+        ok = qc.download_pack(
+            entry["source_repo"],
+            entry.get("source_ref", "main"),
+            entry.get("source_path", "."),
+            dest,
+        )
+        if not ok:
+            return {"name": name, "error": "download failed"}
+        results = qc.check_pack(dest)
+        verdict = results.get("verdict", "REJECTED")
+        return {"name": name, "verdict": verdict, "quality": qc.verdict_to_quality(verdict)}
+    except Exception as exc:  # noqa: BLE001 — one bad pack must not sink the batch
+        return {"name": name, "error": str(exc)}
+    finally:
+        shutil.rmtree(dest, ignore_errors=True)
+
+
+def apply_grades(index_data, results, enum):
+    """Apply graded tiers into a loaded index, returning a maintainer summary.
+
+    Non-destructive: only updates entries via set_entry_quality. An out-of-enum
+    value or a grading error leaves the pack untouched (recorded under errored).
+    """
+    applied = 0
+    tier_counts = {}
+    flagged = []
+    errored = []
+
+    for r in results:
+        name = r["name"]
+        if "error" in r:
+            errored.append(name)
+            continue
+        quality = r["quality"]
+        if quality not in enum:
+            errored.append(name)
+            continue
+        try:
+            if qc.set_entry_quality(index_data, name, quality):
+                applied += 1
+        except KeyError:
+            errored.append(name)
+            continue
+        tier_counts[quality] = tier_counts.get(quality, 0) + 1
+        if quality == "flagged":
+            flagged.append(name)
+
+    return {
+        "graded": len([r for r in results if "error" not in r]),
+        "applied": applied,
+        "tier_counts": tier_counts,
+        "flagged": sorted(flagged),
+        "errored": sorted(errored),
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Backfill pack quality tiers into index.json")
+    parser.add_argument("--index", default="index.json", help="Path to index.json")
+    parser.add_argument("--schema", default="schema/registry-v1.schema.json",
+                        help="Schema whose quality enum the written values are checked against")
+    parser.add_argument("--workers", type=int, default=8, help="Concurrent packs")
+    parser.add_argument("--force-regrade", action="store_true",
+                        help="Re-grade already-graded packs (e.g. after a threshold change)")
+    parser.add_argument("--limit", type=int, help="Grade only the first N packs (smoke test)")
+    parser.add_argument("--packs", help="Comma-separated pack names to grade")
+    parser.add_argument("--summary-json", help="Write the maintainer summary here")
+    args = parser.parse_args()
+
+    with open(args.index, encoding="utf-8") as f:
+        index_data = json.load(f)
+    packs = qc._index_packs(index_data)
+
+    names = [n.strip() for n in args.packs.split(",") if n.strip()] if args.packs else None
+    targets = select_targets(packs, args.force_regrade, args.limit, names)
+
+    print(f"Grading {len(targets)} of {len(packs)} packs "
+          f"(force_regrade={args.force_regrade})...", file=sys.stderr)
+
+    results = []
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = {pool.submit(grade_entry, e): e for e in targets}
+        done = 0
+        for fut in as_completed(futures):
+            results.append(fut.result())
+            done += 1
+            sys.stderr.write(f"\r  graded {done}/{len(targets)} packs")
+            sys.stderr.flush()
+    sys.stderr.write("\n")
+
+    enum = qc.load_quality_enum(args.schema)
+    summary = apply_grades(index_data, results, enum)
+
+    # One serialization-preserving write (reuses the U4 byte-stable writer).
+    text = qc.serialize_index(index_data)
+    json.loads(text)  # guard: never write text that does not parse back
+    with open(args.index, "w", encoding="utf-8") as f:
+        f.write(text)
+
+    print(json.dumps(summary, indent=2))
+
+    sys.stderr.write(
+        f"\nApplied {summary['applied']} tiers. "
+        f"Flagged for maintainer review: {len(summary['flagged'])}\n"
+    )
+    for name in summary["flagged"]:
+        sys.stderr.write(f"  flagged: {name}\n")
+    if summary["errored"]:
+        sys.stderr.write(f"\n{len(summary['errored'])} packs could not be graded (left unreviewed):\n")
+        for name in summary["errored"]:
+            sys.stderr.write(f"  errored: {name}\n")
+
+    if args.summary_json:
+        with open(args.summary_json, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/calibrate-loudness.py
+++ b/.github/scripts/calibrate-loudness.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""calibrate-loudness.py — fit the pack-level loudness thresholds from the catalog.
+
+The pack-level loudness checks (U3) demote a pack from GOLD to SILVER when its
+clips are too inconsistent (wide loudness spread) or uniformly too quiet (low
+pack median). Those two thresholds must come from the catalog's own
+distribution, not a guess, so the backfill does not mass-mislabel reasonable
+packs. This script gathers that distribution.
+
+For each pack it downloads the source tarball, runs the existing audio analysis
+(reusing quality-check.py's download_pack + check_pack), and records the pack's
+loudness spread and median produced by aggregate_pack_loudness. It then prints
+the distribution (percentiles) of per-pack spread and per-pack median, names the
+outliers, and suggests threshold candidates at standard percentiles. The chosen
+values and rationale get written up by hand in QUALITY-CHECK-ANALYSIS.md.
+
+This is a read-only analysis tool. It needs no repository write access.
+
+Usage:
+  python3 calibrate-loudness.py --index index.json                  # full catalog
+  python3 calibrate-loudness.py --index index.json --limit 10       # first 10 (timing)
+  python3 calibrate-loudness.py --index index.json --sample 40      # random 40
+  python3 calibrate-loudness.py --index index.json --packs arnold,abbot
+  python3 calibrate-loudness.py --index index.json --workers 6 --output-json dist.json
+
+Dependencies: Python 3.8+, ffmpeg/ffprobe. No pip packages.
+"""
+
+import argparse
+import importlib.util
+import json
+import os
+import random
+import shutil
+import statistics
+import sys
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+# Load the checker module by path (hyphen + dotted dir make it non-importable by name).
+_CHECKER_PATH = Path(__file__).resolve().parent / "quality-check.py"
+_spec = importlib.util.spec_from_file_location("quality_check", _CHECKER_PATH)
+qc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(qc)
+
+
+def load_packs(index_path):
+    """Return the list of pack entries from an index.json (list or {'packs': [...]})."""
+    with open(index_path) as f:
+        index = json.load(f)
+    return index if isinstance(index, list) else index.get("packs", [])
+
+
+def measure_pack(entry):
+    """Download and grade one pack. Returns a result dict (never raises)."""
+    name = entry.get("name", "?")
+    dest = tempfile.mkdtemp(prefix=f"cal-{name}-")
+    try:
+        ok = qc.download_pack(
+            entry["source_repo"],
+            entry.get("source_ref", "main"),
+            entry.get("source_path", "."),
+            dest,
+        )
+        if not ok:
+            return {"name": name, "error": "download failed"}
+        results = qc.check_pack(dest)
+        metrics = results.get("pack_metrics", {})
+        return {
+            "name": name,
+            "verdict": results.get("verdict"),
+            "total_files": results.get("total_files", 0),
+            "loudness_spread": metrics.get("loudness_spread"),
+            "loudness_median": metrics.get("loudness_median"),
+            "measured_clips": metrics.get("measured_clips", 0),
+        }
+    except Exception as exc:  # noqa: BLE001 — calibration must survive one bad pack
+        return {"name": name, "error": str(exc)}
+    finally:
+        shutil.rmtree(dest, ignore_errors=True)
+
+
+def percentile(sorted_values, pct):
+    """Linear-interpolation percentile (pct in 0..100) over a pre-sorted list."""
+    if not sorted_values:
+        return None
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = (pct / 100) * (len(sorted_values) - 1)
+    lo = int(rank)
+    hi = min(lo + 1, len(sorted_values) - 1)
+    frac = rank - lo
+    return sorted_values[lo] + (sorted_values[hi] - sorted_values[lo]) * frac
+
+
+def describe(values):
+    """Summary stats + standard percentiles for a list of numbers."""
+    if not values:
+        return None
+    s = sorted(values)
+    pcts = [5, 10, 25, 50, 75, 90, 95, 99]
+    return {
+        "count": len(s),
+        "min": round(min(s), 1),
+        "max": round(max(s), 1),
+        "mean": round(statistics.mean(s), 1),
+        "percentiles": {p: round(percentile(s, p), 1) for p in pcts},
+    }
+
+
+def run(entries, workers):
+    """Measure all entries concurrently, returning (results, elapsed_seconds)."""
+    results = []
+    start = time.monotonic()
+    done = 0
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {pool.submit(measure_pack, e): e for e in entries}
+        for fut in as_completed(futures):
+            results.append(fut.result())
+            done += 1
+            sys.stderr.write(f"\r  graded {done}/{len(entries)} packs")
+            sys.stderr.flush()
+    sys.stderr.write("\n")
+    return results, time.monotonic() - start
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Calibrate pack-level loudness thresholds")
+    parser.add_argument("--index", default="index.json", help="Path to index.json")
+    parser.add_argument("--limit", type=int, help="Grade only the first N packs (timing)")
+    parser.add_argument("--sample", type=int, help="Grade a random N-pack sample")
+    parser.add_argument("--packs", help="Comma-separated pack names to grade")
+    parser.add_argument("--seed", type=int, default=1770, help="Random seed for --sample")
+    parser.add_argument("--workers", type=int, default=4, help="Concurrent packs")
+    parser.add_argument("--output-json", help="Write full distribution + per-pack data here")
+    args = parser.parse_args()
+
+    entries = load_packs(args.index)
+    by_name = {e.get("name"): e for e in entries}
+
+    if args.packs:
+        wanted = [n.strip() for n in args.packs.split(",") if n.strip()]
+        entries = [by_name[n] for n in wanted if n in by_name]
+        missing = [n for n in wanted if n not in by_name]
+        if missing:
+            print(f"Not in index: {', '.join(missing)}", file=sys.stderr)
+    elif args.sample:
+        rng = random.Random(args.seed)
+        entries = rng.sample(entries, min(args.sample, len(entries)))
+    elif args.limit:
+        entries = entries[: args.limit]
+
+    print(f"Grading {len(entries)} packs with {args.workers} workers...", file=sys.stderr)
+    results, elapsed = run(entries, args.workers)
+
+    graded = [r for r in results if "error" not in r]
+    errored = [r for r in results if "error" in r]
+    spreads = [r["loudness_spread"] for r in graded if r["loudness_spread"] is not None]
+    medians = [r["loudness_median"] for r in graded if r["loudness_median"] is not None]
+
+    spread_dist = describe(spreads)
+    median_dist = describe(medians)
+
+    # Threshold candidates: flag the uneven tail (high spread) and the quiet tail
+    # (low median). p90 spread and p10 median are starting points; the final cut
+    # is chosen and justified by hand in QUALITY-CHECK-ANALYSIS.md.
+    suggestions = {}
+    if spread_dist:
+        suggestions["spread_threshold_candidates"] = {
+            "p90": spread_dist["percentiles"][90],
+            "p95": spread_dist["percentiles"][95],
+        }
+    if median_dist:
+        suggestions["quiet_floor_candidates"] = {
+            "p10": median_dist["percentiles"][10],
+            "p5": median_dist["percentiles"][5],
+        }
+
+    # Per-pack timing helps size the U5 backfill against the 6h CI ceiling.
+    total_files = sum(r.get("total_files", 0) for r in graded)
+    timing = {
+        "elapsed_s": round(elapsed, 1),
+        "packs": len(results),
+        "files": total_files,
+        "s_per_pack": round(elapsed / len(results), 2) if results else None,
+        "s_per_file": round(elapsed / total_files, 3) if total_files else None,
+    }
+
+    report = {
+        "graded": len(graded),
+        "errored": [r["name"] for r in errored],
+        "spread_distribution": spread_dist,
+        "median_distribution": median_dist,
+        "suggestions": suggestions,
+        "timing": timing,
+        "per_pack": sorted(graded, key=lambda r: (r["loudness_spread"] is None, -(r["loudness_spread"] or 0))),
+    }
+
+    print(json.dumps(report, indent=2, default=str))
+
+    if args.output_json:
+        with open(args.output_json, "w") as f:
+            json.dump(report, f, indent=2, default=str)
+
+    # Human-facing tail callouts on stderr so they survive a piped stdout.
+    if spread_dist:
+        p90 = spread_dist["percentiles"][90]
+        loud_outliers = [r for r in graded if (r["loudness_spread"] or 0) >= p90]
+        sys.stderr.write(f"\nWidest-spread packs (>= p90 = {p90} LU):\n")
+        for r in sorted(loud_outliers, key=lambda r: -(r["loudness_spread"] or 0))[:15]:
+            sys.stderr.write(f"  {r['name']:<24} spread {r['loudness_spread']} LU, median {r['loudness_median']} LUFS\n")
+    if median_dist:
+        p10 = median_dist["percentiles"][10]
+        quiet_outliers = [r for r in graded if r["loudness_median"] is not None and r["loudness_median"] <= p10]
+        sys.stderr.write(f"\nQuietest packs (<= p10 median = {p10} LUFS):\n")
+        for r in sorted(quiet_outliers, key=lambda r: (r["loudness_median"] or 0))[:15]:
+            sys.stderr.write(f"  {r['name']:<24} median {r['loudness_median']} LUFS, spread {r['loudness_spread']} LU\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/quality-check.py
+++ b/.github/scripts/quality-check.py
@@ -525,7 +525,11 @@ def download_pack(source_repo, source_ref, source_path, dest_dir):
 
     tmp = tempfile.NamedTemporaryFile(suffix=".tar.gz", delete=False)
     try:
-        urllib.request.urlretrieve(tarball_url, tmp.name)
+        # Stream with a timeout so a stalled GitHub response cannot hang the
+        # persist/backfill runner indefinitely (urlretrieve has no timeout).
+        with urllib.request.urlopen(tarball_url, timeout=60) as resp:
+            with open(tmp.name, "wb") as out:
+                shutil.copyfileobj(resp, out)
         with tarfile.open(tmp.name, "r:gz") as tf:
             members = tf.getmembers()
             if not members:

--- a/.github/scripts/quality-check.py
+++ b/.github/scripts/quality-check.py
@@ -64,6 +64,12 @@ SILENCE_THRESHOLD_DB = -35
 # the per-file loudness check and the pack-level loudness aggregation.
 LOUDNESS_MIN_DURATION_S = 0.5
 
+# Pack-level loudness WARN thresholds — calibrated against the full catalog's
+# distribution. See QUALITY-CHECK-ANALYSIS.md. These are score-only: they demote
+# GOLD to SILVER, never REJECTED.
+LOUDNESS_SPREAD_WARN_LU = 15.0    # range between quietest and loudest clip (p90)
+LOUDNESS_QUIET_PACK_LUFS = -26.0  # pack median at or below this reads as too quiet
+
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Audio analysis helpers
@@ -294,6 +300,59 @@ def aggregate_pack_loudness(file_results):
     }
 
 
+def pack_loudness_warnings(pack_metrics):
+    """Pack-level loudness warnings from the calibrated thresholds.
+
+    Pure function so the demotion logic is testable without ffmpeg. Returns a
+    list of warning dicts, each carrying a summary key, a short message, and a
+    contributor-facing detail naming the measured value and the GOLD target.
+    These are WARNS: they flow through the existing "any warn -> SILVER" path and
+    can only demote GOLD to SILVER, never produce REJECTED.
+    """
+    warnings = []
+    if not pack_metrics:
+        return warnings
+
+    spread = pack_metrics.get("loudness_spread")
+    median = pack_metrics.get("loudness_median")
+
+    if spread is not None and spread > LOUDNESS_SPREAD_WARN_LU:
+        warnings.append({
+            "key": "inconsistent_loudness",
+            "message": "inconsistent loudness across clips",
+            "detail": (
+                f"clips span {spread:.1f} LU, GOLD needs {LOUDNESS_SPREAD_WARN_LU:.0f} LU or less "
+                f"(normalize the quietest and loudest clips closer together)"
+            ),
+        })
+
+    if median is not None and median <= LOUDNESS_QUIET_PACK_LUFS:
+        warnings.append({
+            "key": "uniformly_quiet",
+            "message": "pack is uniformly quiet",
+            "detail": (
+                f"pack median {median:.1f} LUFS, GOLD needs above {LOUDNESS_QUIET_PACK_LUFS:.0f} LUFS "
+                f"(normalize toward about -16 LUFS)"
+            ),
+        })
+
+    return warnings
+
+
+def decide_verdict(total_blocks, total_warns):
+    """Map block/warn counts to the three-tier verdict.
+
+    Extracted as a pure function so the score-only demotion is testable: any
+    block forces REJECTED, any warn (including the pack-level loudness warns)
+    demotes to SILVER, and a clean pack is GOLD.
+    """
+    if total_blocks > 0:
+        return "REJECTED"
+    if total_warns > 0:
+        return "SILVER"
+    return "GOLD"
+
+
 def check_pack(pack_dir):
     """Run all quality checks on a local pack directory.
 
@@ -401,16 +460,15 @@ def check_pack(pack_dir):
 
     sys.stderr.write("\r" + " " * 70 + "\r")
 
-    # Pack-level loudness consistency (measure and report only, no verdict impact).
+    # Pack-level loudness: measure, then apply the calibrated score-only warns.
+    # These are warns, so they demote GOLD to SILVER but never REJECTED (KTD3).
     pack_metrics = aggregate_pack_loudness(file_results)
+    pack_warnings = pack_loudness_warnings(pack_metrics)
+    for w in pack_warnings:
+        total_warns += 1
+        warn_summary[w["key"]] += 1
 
-    # Determine verdict
-    if total_blocks > 0:
-        verdict = "REJECTED"
-    elif total_warns > 0:
-        verdict = "SILVER"
-    else:
-        verdict = "GOLD"
+    verdict = decide_verdict(total_blocks, total_warns)
 
     return {
         "pack_name": pack_name,
@@ -422,6 +480,7 @@ def check_pack(pack_dir):
         "block_summary": dict(block_summary),
         "warn_summary": dict(warn_summary),
         "pack_metrics": pack_metrics,
+        "pack_warnings": pack_warnings,
         "files": file_results,
     }
 
@@ -547,10 +606,16 @@ def format_markdown(results):
             lines.append(f"| {issue.replace('_', ' ').title()} | {count} |")
         lines.append("")
 
-    # Pack-level loudness metrics (report only; does not affect the verdict yet)
+    # Pack-level loudness metrics and any score-only loudness warnings.
     loudness = format_pack_loudness_summary(results.get("pack_metrics"))
     if loudness:
         lines.append(f"**Pack loudness** — {loudness}\n")
+    pack_warnings = results.get("pack_warnings", [])
+    if pack_warnings:
+        lines.append("These pack-level findings demote the tier to SILVER:\n")
+        for pw in pack_warnings:
+            lines.append(f"- **{pw['message']}** — {pw['detail']}")
+        lines.append("")
 
     # Threshold reference
     lines.append("<details><summary>Threshold reference</summary>\n")
@@ -563,6 +628,8 @@ def format_markdown(results):
     lines.append(f"| Bitrate | — | < {BITRATE_WARN_KBPS} kbps |")
     lines.append(f"| Sample rate | < {SAMPLE_RATE_BLOCK_HZ} Hz | < {SAMPLE_RATE_WARN_HZ} Hz |")
     lines.append(f"| Duration | > {DURATION_MAX_BLOCK_S}s or < {DURATION_MIN_BLOCK_S}s | > {DURATION_LONG_WARN_S}s |")
+    lines.append(f"| Pack loudness spread | — | > {LOUDNESS_SPREAD_WARN_LU:.0f} LU |")
+    lines.append(f"| Pack median loudness | — | <= {LOUDNESS_QUIET_PACK_LUFS:.0f} LUFS |")
     lines.append("\n</details>")
 
     return "\n".join(lines)
@@ -600,6 +667,8 @@ def format_console(results):
     loudness = format_pack_loudness_summary(results.get("pack_metrics"))
     if loudness:
         print(f"  Loudness: {loudness}")
+    for pw in results.get("pack_warnings", []):
+        print(f"  Pack warning: {pw['message']} — {pw['detail']}")
     print(f"  Verdict: {verdict}")
     print(f"{'━' * 60}")
 

--- a/.github/scripts/quality-check.py
+++ b/.github/scripts/quality-check.py
@@ -25,6 +25,7 @@ Exit codes:
 import json
 import os
 import re
+import statistics
 import subprocess
 import sys
 import tarfile
@@ -57,6 +58,11 @@ SAMPLE_RATE_WARN_HZ = 16000      # Low but functional
 
 # Silence detection sensitivity
 SILENCE_THRESHOLD_DB = -35
+
+# Integrated loudness needs >= ~400ms of audio to be reliable (ITU-R BS.1770).
+# Clips shorter than this report no trustworthy LUFS and are excluded from both
+# the per-file loudness check and the pack-level loudness aggregation.
+LOUDNESS_MIN_DURATION_S = 0.5
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -219,7 +225,7 @@ def classify_file(filepath):
         stats["lufs"] = round(lufs, 1) if lufs != float("-inf") else "-inf"
         # loudnorm needs >= 400ms to compute integrated loudness (ITU-R BS.1770).
         # Files shorter than that report -inf, which is not a real silence reading.
-        if lufs == float("-inf") and duration < 0.5:
+        if lufs == float("-inf") and duration < LOUDNESS_MIN_DURATION_S:
             pass  # skip — too short for reliable loudness measurement
         elif lufs == float("-inf") or lufs < LUFS_BLOCK_FLOOR:
             blocks.append(f"file is silent or nearly silent")
@@ -234,6 +240,59 @@ def classify_file(filepath):
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Pack-level analysis
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+def aggregate_pack_loudness(file_results):
+    """Aggregate per-file loudness into pack-level spread and median.
+
+    Pure function over the dicts ``classify_file`` returns, so it is testable
+    without ffmpeg. Reads each file's ``stats["lufs"]`` and ``stats["duration"]``,
+    which are heterogeneous: ``lufs`` is a float for a normal clip, the string
+    ``"-inf"`` for a silent clip, and absent when loudnorm timed out or failed to
+    parse. Three classes of clip carry no trustworthy integrated loudness and are
+    excluded from both metrics:
+
+      - ``lufs`` absent (measurement failed),
+      - ``lufs`` is ``"-inf"`` / ``-inf`` (silent),
+      - clip shorter than ``LOUDNESS_MIN_DURATION_S`` (too short to measure per
+        ITU-R BS.1770, even when it returns a finite number).
+
+    Returns a dict:
+      - ``loudness_spread``: max - min LUFS across measurable clips (LU), rounded
+        to 0.1, or ``None`` when fewer than two clips are measurable (a spread is
+        undeterminable from one point).
+      - ``loudness_median``: median LUFS across measurable clips, rounded to 0.1,
+        or ``None`` when none are measurable.
+      - ``measured_clips``: how many clips contributed to the metrics.
+    """
+    lufs_values = []
+    for result in file_results:
+        stats = result.get("stats", {})
+        lufs = stats.get("lufs")
+        duration = stats.get("duration")
+
+        if lufs is None or duration is None:
+            continue
+        if lufs == "-inf" or (isinstance(lufs, float) and lufs == float("-inf")):
+            continue
+        if not isinstance(lufs, (int, float)):
+            continue
+        if duration < LOUDNESS_MIN_DURATION_S:
+            continue
+
+        lufs_values.append(float(lufs))
+
+    spread = None
+    if len(lufs_values) >= 2:
+        spread = round(max(lufs_values) - min(lufs_values), 1)
+
+    median = round(statistics.median(lufs_values), 1) if lufs_values else None
+
+    return {
+        "loudness_spread": spread,
+        "loudness_median": median,
+        "measured_clips": len(lufs_values),
+    }
+
 
 def check_pack(pack_dir):
     """Run all quality checks on a local pack directory.
@@ -342,6 +401,9 @@ def check_pack(pack_dir):
 
     sys.stderr.write("\r" + " " * 70 + "\r")
 
+    # Pack-level loudness consistency (measure and report only, no verdict impact).
+    pack_metrics = aggregate_pack_loudness(file_results)
+
     # Determine verdict
     if total_blocks > 0:
         verdict = "REJECTED"
@@ -359,6 +421,7 @@ def check_pack(pack_dir):
         "total_warns": total_warns,
         "block_summary": dict(block_summary),
         "warn_summary": dict(warn_summary),
+        "pack_metrics": pack_metrics,
         "files": file_results,
     }
 
@@ -409,6 +472,23 @@ def download_pack(source_repo, source_ref, source_path, dest_dir):
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 # Output formatting
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+def format_pack_loudness_summary(pack_metrics):
+    """One-line human summary of pack loudness, or None when nothing is measurable."""
+    if not pack_metrics:
+        return None
+    measured = pack_metrics.get("measured_clips", 0)
+    if not measured:
+        return None
+
+    median = pack_metrics.get("loudness_median")
+    spread = pack_metrics.get("loudness_spread")
+    clip_word = "clip" if measured == 1 else "clips"
+
+    if spread is None:
+        return f"median {median:.1f} LUFS ({measured} measurable {clip_word}; spread needs >= 2)"
+    return f"spread {spread:.1f} LU, median {median:.1f} LUFS across {measured} measurable {clip_word}"
+
 
 def format_markdown(results):
     """Format results as a GitHub-flavored Markdown section."""
@@ -467,6 +547,11 @@ def format_markdown(results):
             lines.append(f"| {issue.replace('_', ' ').title()} | {count} |")
         lines.append("")
 
+    # Pack-level loudness metrics (report only; does not affect the verdict yet)
+    loudness = format_pack_loudness_summary(results.get("pack_metrics"))
+    if loudness:
+        lines.append(f"**Pack loudness** — {loudness}\n")
+
     # Threshold reference
     lines.append("<details><summary>Threshold reference</summary>\n")
     lines.append("| Check | Block | Warn |")
@@ -512,6 +597,9 @@ def format_console(results):
 
     print(f"\n{'─' * 60}")
     print(f"  Files: {total_files}  |  Blocks: {total_blocks}  |  Warnings: {total_warns}")
+    loudness = format_pack_loudness_summary(results.get("pack_metrics"))
+    if loudness:
+        print(f"  Loudness: {loudness}")
     print(f"  Verdict: {verdict}")
     print(f"{'━' * 60}")
 

--- a/.github/scripts/quality-check.py
+++ b/.github/scripts/quality-check.py
@@ -25,6 +25,7 @@ Exit codes:
 import json
 import os
 import re
+import shutil
 import statistics
 import subprocess
 import sys
@@ -353,6 +354,21 @@ def decide_verdict(total_blocks, total_warns):
     return "GOLD"
 
 
+def verdict_to_quality(verdict):
+    """Map a checker verdict to the stored index.json quality enum (KTD4).
+
+    GOLD -> gold, SILVER -> silver, REJECTED -> flagged. Anything else (an
+    ungraded or unexpected value) maps to the schema default, unreviewed. The
+    lowercase enum lives only in index.json; the checker keeps GOLD/SILVER/
+    REJECTED internally.
+    """
+    return {
+        "GOLD": "gold",
+        "SILVER": "silver",
+        "REJECTED": "flagged",
+    }.get(verdict, "unreviewed")
+
+
 def check_pack(pack_dir):
     """Run all quality checks on a local pack directory.
 
@@ -489,6 +505,19 @@ def check_pack(pack_dir):
 # Pack download (for CI use)
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+def _is_within_directory(base_dir, target_path):
+    """True only if target_path resolves inside base_dir.
+
+    Guards tarball extraction against path-traversal members (e.g. a member
+    named `top/../../etc/...`) that would otherwise write outside the temp
+    pack directory. The grading jobs extract contributor-controlled tarballs
+    while holding write access, so this check is load-bearing (KTD11).
+    """
+    base_real = os.path.realpath(base_dir)
+    target_real = os.path.realpath(target_path)
+    return target_real == base_real or target_real.startswith(base_real + os.sep)
+
+
 def download_pack(source_repo, source_ref, source_path, dest_dir):
     """Download a pack from GitHub to a local directory."""
     tarball_url = f"https://github.com/{source_repo}/archive/{source_ref}.tar.gz"
@@ -512,6 +541,11 @@ def download_pack(source_repo, source_ref, source_path, dest_dir):
                     if not rel:
                         continue
                     dest = os.path.join(dest_dir, rel)
+                    if not _is_within_directory(dest_dir, dest):
+                        print(f"Skipping unsafe tarball member: {m.name}", file=sys.stderr)
+                        continue
+                    # Only regular files and dirs are extracted; symlinks and
+                    # hardlinks (m.issym/m.islnk) fall through and are ignored.
                     if m.isdir():
                         os.makedirs(dest, exist_ok=True)
                     elif m.isfile():
@@ -526,6 +560,83 @@ def download_pack(source_repo, source_ref, source_path, dest_dir):
         return False
     finally:
         os.unlink(tmp.name)
+
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Quality persistence (write-back into index.json)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUALITY_ENUM_FALLBACK = ("gold", "silver", "flagged", "unreviewed")
+
+
+def load_quality_enum(schema_path):
+    """Read the allowed quality values from the registry schema.
+
+    Falls back to the known enum if the schema cannot be read, so a missing or
+    moved schema file degrades to a still-valid guard rather than crashing.
+    """
+    try:
+        with open(schema_path, encoding="utf-8") as f:
+            schema = json.load(f)
+        return tuple(schema["$defs"]["pack"]["properties"]["quality"]["enum"])
+    except Exception:
+        return QUALITY_ENUM_FALLBACK
+
+
+def _index_packs(index_data):
+    """The pack list from an index that is either a bare list or {'packs': [...]}."""
+    return index_data if isinstance(index_data, list) else index_data.get("packs", [])
+
+
+def set_entry_quality(index_data, pack_name, quality):
+    """Set one pack entry's quality in a loaded index. Returns True if it changed.
+
+    Mutates only the target entry, leaving every other entry untouched. Raises
+    KeyError if the pack is absent.
+    """
+    for entry in _index_packs(index_data):
+        if entry.get("name") == pack_name:
+            if entry.get("quality") == quality:
+                return False
+            entry["quality"] = quality
+            return True
+    raise KeyError(f"pack '{pack_name}' not found in index")
+
+
+def serialize_index(index_data):
+    """Serialize an index dict to index.json's exact on-disk shape.
+
+    4-space indent, ensure_ascii=False (the catalog stores raw non-ASCII
+    descriptions that a default json.dump would escape across hundreds of
+    lines), trailing newline. A load -> serialize round-trip is byte-identical,
+    so editing one entry's quality leaves every other entry byte-for-byte
+    unchanged (KTD10).
+    """
+    return json.dumps(index_data, indent=4, ensure_ascii=False) + "\n"
+
+
+def write_pack_quality(index_path, pack_name, quality, schema_path=None):
+    """Persist one pack's quality into index.json, surgically and validated.
+
+    Asserts the value is in the schema enum before touching the file, edits only
+    that entry, and re-serializes preserving the file's shape. Returns True if
+    the file changed (False is a clean no-op for idempotent re-runs). Raises
+    ValueError on an out-of-enum value, KeyError if the pack is absent.
+    """
+    enum = load_quality_enum(schema_path) if schema_path else QUALITY_ENUM_FALLBACK
+    if quality not in enum:
+        raise ValueError(f"quality '{quality}' is not in the schema enum {enum}")
+
+    with open(index_path, encoding="utf-8") as f:
+        index_data = json.load(f)
+
+    changed = set_entry_quality(index_data, pack_name, quality)
+    if changed:
+        text = serialize_index(index_data)
+        json.loads(text)  # guard: never write text that does not parse back
+        with open(index_path, "w", encoding="utf-8") as f:
+            f.write(text)
+    return changed
 
 
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -677,6 +788,44 @@ def format_console(results):
 # Main
 # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
+def run_apply_quality(args):
+    """Grade one pack and persist its quality tier into index.json.
+
+    Downloads the pack (pinning to --source-ref when given, so a post-review
+    content swap cannot change what gets persisted, KTD11), grades it, maps the
+    verdict to the quality enum, and writes that one entry. Exits non-zero on
+    any failure so the persist job fails loudly rather than writing nothing.
+    """
+    if not args.index or not args.pack:
+        print("--apply-quality requires --index and --pack", file=sys.stderr)
+        sys.exit(2)
+
+    with open(args.index, encoding="utf-8") as f:
+        index_data = json.load(f)
+    entry = next((p for p in _index_packs(index_data) if p.get("name") == args.pack), None)
+    if not entry:
+        print(f"Pack '{args.pack}' not found in {args.index}", file=sys.stderr)
+        sys.exit(2)
+
+    ref = args.source_ref or entry.get("source_ref", "main")
+    dest = tempfile.mkdtemp(prefix=f"persist-{args.pack}-")
+    try:
+        print(f"Grading {args.pack} from {entry['source_repo']}@{ref}...")
+        ok = download_pack(entry["source_repo"], ref, entry.get("source_path", "."), dest)
+        if not ok:
+            print(f"Failed to download pack '{args.pack}'", file=sys.stderr)
+            sys.exit(2)
+
+        results = check_pack(dest)
+        verdict = results.get("verdict", "REJECTED")
+        quality = verdict_to_quality(verdict)
+        changed = write_pack_quality(args.index, args.pack, quality, args.schema)
+        state = "updated" if changed else "unchanged"
+        print(f"{args.pack}: verdict {verdict} -> quality '{quality}' ({state})")
+    finally:
+        shutil.rmtree(dest, ignore_errors=True)
+
+
 def main():
     import argparse
 
@@ -692,6 +841,18 @@ def main():
                         help="Write results as Markdown to this file")
     parser.add_argument("--quiet", action="store_true",
                         help="Suppress console output (use with --output-*)")
+    # Persist mode: grade one pack and write its quality tier into index.json.
+    parser.add_argument("--apply-quality", action="store_true",
+                        help="Grade a pack and persist its quality into --index (post-merge)")
+    parser.add_argument("--index", metavar="INDEX_JSON",
+                        help="index.json to write the quality tier into (with --apply-quality)")
+    parser.add_argument("--pack", metavar="NAME",
+                        help="Pack name to grade and persist (with --apply-quality)")
+    parser.add_argument("--schema", metavar="SCHEMA_JSON",
+                        default="schema/registry-v1.schema.json",
+                        help="Schema whose quality enum the written value is checked against")
+    parser.add_argument("--source-ref", metavar="REF",
+                        help="Override the pack's source_ref (pin to the reviewed SHA, KTD11)")
 
     args = parser.parse_args()
 
@@ -701,6 +862,10 @@ def main():
     except FileNotFoundError:
         print("Error: ffprobe not found. Install ffmpeg.", file=sys.stderr)
         sys.exit(2)
+
+    if args.apply_quality:
+        run_apply_quality(args)
+        return
 
     pack_dir = args.pack_dir
 

--- a/.github/workflows/backfill-quality.yml
+++ b/.github/workflows/backfill-quality.yml
@@ -1,0 +1,118 @@
+name: Backfill Quality
+
+# One-time (re-runnable) grade of the whole catalog into index.json. Writes to a
+# branch and opens a PR so a maintainer reviews the catalog-wide change before it
+# lands on main. Non-destructive: entries are only updated, never removed.
+#
+# The full catalog grades in about 7.5 minutes (~1.3s per pack), well under the
+# 6-hour job ceiling, so a single job suffices. Use the limit input to smoke-test
+# a small subset first.
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_regrade:
+        description: "Re-grade every pack, including already-graded ones (e.g. after a threshold change)"
+        type: boolean
+        default: false
+      limit:
+        description: "Grade only the first N packs (smoke test). Blank grades the full catalog."
+        type: string
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  backfill:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          token: ${{ secrets.PERSIST_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg > /dev/null 2>&1
+          ffprobe -version | head -1
+
+      - name: Grade catalog and write tiers
+        env:
+          FORCE: ${{ inputs.force_regrade }}
+          LIMIT: ${{ inputs.limit }}
+        run: |
+          ARGS="--index index.json --workers 8 --summary-json backfill-summary.json"
+          if [ "$FORCE" = "true" ]; then ARGS="$ARGS --force-regrade"; fi
+          if [ -n "$LIMIT" ]; then ARGS="$ARGS --limit $LIMIT"; fi
+          python3 .github/scripts/backfill-quality.py $ARGS
+
+      - name: Validate index.json
+        run: |
+          python3 - <<'PYEOF'
+          import json, sys
+
+          with open('schema/registry-v1.schema.json', encoding='utf-8') as f:
+              enum = set(json.load(f)['$defs']['pack']['properties']['quality']['enum'])
+          with open('index.json', encoding='utf-8') as f:
+              data = json.load(f)
+          bad = [p['name'] for p in data.get('packs', [])
+                 if 'quality' in p and p['quality'] not in enum]
+          if bad:
+              print(f'Out-of-enum quality on: {bad}', file=sys.stderr)
+              sys.exit(1)
+          print(f'index.json valid; {len(data.get("packs", []))} packs')
+          PYEOF
+
+      - name: Open backfill PR
+        env:
+          GH_TOKEN: ${{ secrets.PERSIST_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          if git diff --quiet index.json; then
+            echo "No tier changes to backfill"
+            exit 0
+          fi
+          BRANCH="backfill-quality-${{ github.run_id }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add index.json
+          git commit -m "chore(quality): backfill computed tiers across the catalog"
+          git push origin "$BRANCH"
+
+          # Build the PR body from the maintainer summary.
+          python3 - <<'PYEOF' > pr-body.md
+          import json
+
+          s = json.load(open('backfill-summary.json'))
+          print("Automated catalog-wide quality backfill. Review before merging.\n")
+          print(f"- Graded: {s['graded']}")
+          print(f"- Tiers applied: {s['applied']}")
+          print(f"- Tier counts: {s['tier_counts']}\n")
+          flagged = s['flagged']
+          print(f"**Flagged packs for maintainer review ({len(flagged)}):**")
+          if flagged:
+              for n in flagged:
+                  print(f"- {n}")
+          else:
+              print("- none")
+          errored = s['errored']
+          if errored:
+              print(f"\n**Could not grade ({len(errored)}, left unreviewed):**")
+              for n in errored:
+                  print(f"- {n}")
+          PYEOF
+
+          gh pr create --base main --head "$BRANCH" \
+            --title "Backfill pack quality tiers" \
+            --body-file pr-body.md
+
+      - name: Upload summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backfill-summary
+          path: backfill-summary.json
+          retention-days: 90

--- a/.github/workflows/persist-quality.yml
+++ b/.github/workflows/persist-quality.yml
@@ -1,0 +1,155 @@
+name: Persist Quality
+
+# Post-merge persistence of the CI-computed quality tier into index.json on main.
+#
+# The PR path (validate-index.yml) runs on pull_request_target and cannot push a
+# computed tier back to a contributor's fork branch, so main is the single source
+# of truth that GitHub Pages serves (KTD2). After a pack lands on main, this job
+# grades the changed pack(s), maps the verdict to the quality enum, and writes
+# that tier into the pack's entry. The write-back commit carries [skip ci], which
+# GitHub honors for push events, so it does not re-trigger this workflow.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'index.json'
+
+# Serialize runs so two near-simultaneous merges cannot clobber each other's
+# tier. Do not cancel an in-flight persist mid-write (KTD10).
+concurrency:
+  group: persist-quality
+  cancel-in-progress: false
+
+# Least privilege: this job only needs to push the quality write-back.
+permissions:
+  contents: write
+
+jobs:
+  persist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 2  # diff HEAD against the pre-merge commit to find changes
+          # PERSIST_TOKEN is an optional PAT with push-bypass on main, for when
+          # branch protection blocks the default bot. Falls back to GITHUB_TOKEN.
+          token: ${{ secrets.PERSIST_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Detect changed packs
+        id: detect
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, subprocess
+
+          def load(ref):
+              r = subprocess.run(['git', 'show', f'{ref}:index.json'],
+                                 capture_output=True, text=True)
+              if r.returncode != 0:
+                  return {}
+              return {p['name']: p for p in json.loads(r.stdout).get('packs', [])}
+
+          head = load('HEAD')
+          base = load('HEAD~1')  # may be empty on a shallow/first commit
+
+          # A pack needs grading when it is new or when its content changed,
+          # ignoring the quality field itself so our own write-backs are no-ops.
+          # This is correct for the common single-squashed-pack merge.
+          changed = []
+          for name, entry in head.items():
+              prev = base.get(name)
+              if prev is None:
+                  changed.append(name)
+                  continue
+              a = {k: v for k, v in entry.items() if k != 'quality'}
+              b = {k: v for k, v in prev.items() if k != 'quality'}
+              if a != b:
+                  changed.append(name)
+
+          print('Changed packs:', changed)
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'packs={json.dumps(changed)}\n')
+              f.write(f'count={len(changed)}\n')
+          PYEOF
+
+      - name: Install ffmpeg
+        if: steps.detect.outputs.count != '0'
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq ffmpeg > /dev/null 2>&1
+          ffprobe -version | head -1
+
+      - name: Grade and persist quality
+        if: steps.detect.outputs.count != '0'
+        env:
+          PACKS: ${{ steps.detect.outputs.packs }}
+        run: |
+          python3 - <<'PYEOF'
+          import json, os, subprocess, sys
+
+          for name in json.loads(os.environ['PACKS']):
+              r = subprocess.run([
+                  'python3', '.github/scripts/quality-check.py',
+                  '--apply-quality', '--index', 'index.json', '--pack', name,
+                  '--schema', 'schema/registry-v1.schema.json',
+              ])
+              if r.returncode != 0:
+                  print(f'Failed to persist quality for {name}', file=sys.stderr)
+                  sys.exit(1)
+          PYEOF
+
+      - name: Validate index.json before commit
+        if: steps.detect.outputs.count != '0'
+        run: |
+          python3 - <<'PYEOF'
+          import json, sys
+
+          # The post-merge push does not run validate-index, so guard the write
+          # here: the file must still parse and every quality must be in the enum.
+          with open('schema/registry-v1.schema.json', encoding='utf-8') as f:
+              enum = set(json.load(f)['$defs']['pack']['properties']['quality']['enum'])
+          with open('index.json', encoding='utf-8') as f:
+              data = json.load(f)
+          bad = [p['name'] for p in data.get('packs', [])
+                 if 'quality' in p and p['quality'] not in enum]
+          if bad:
+              print(f'Out-of-enum quality on: {bad}', file=sys.stderr)
+              sys.exit(1)
+          print(f'index.json valid; {len(data.get("packs", []))} packs, quality values in enum')
+          PYEOF
+
+      - name: Commit and push
+        id: commit
+        if: steps.detect.outputs.count != '0'
+        run: |
+          if git diff --quiet index.json; then
+            echo "No quality change to persist"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add index.json
+          git commit -m "chore(quality): persist computed tier(s) [skip ci]"
+          # A concurrent merge may have advanced main; rebase before pushing.
+          git pull --rebase origin main
+          if ! git push origin HEAD:main; then
+            echo "::error::Push to main was rejected. Branch protection likely blocks the bot's direct push. Configure a push bypass for github-actions, or set a PERSIST_TOKEN secret (a PAT with bypass). The job fails rather than silently writing nothing."
+            exit 1
+          fi
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger openpeon.com rebuild
+        if: steps.commit.outputs.pushed == 'true'
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: |
+          # The deploy hook fires only on the PR path in validate-index.yml, so
+          # without this POST the badge would wait for the site's 24h revalidate.
+          if [ -z "$VERCEL_DEPLOY_HOOK" ]; then
+            echo "VERCEL_DEPLOY_HOOK not configured; skipping rebuild trigger"
+          else
+            echo "Triggering openpeon.com rebuild..."
+            curl -fSL -X POST "$VERCEL_DEPLOY_HOOK"
+          fi

--- a/.github/workflows/persist-quality.yml
+++ b/.github/workflows/persist-quality.yml
@@ -151,5 +151,5 @@ jobs:
             echo "VERCEL_DEPLOY_HOOK not configured; skipping rebuild trigger"
           else
             echo "Triggering openpeon.com rebuild..."
-            curl -fSL -X POST "$VERCEL_DEPLOY_HOOK"
+            curl -fSL --max-time 30 -X POST "$VERCEL_DEPLOY_HOOK"
           fi

--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -30,6 +30,20 @@ jobs:
 
           errors = []
 
+          # quality is a CI-owned field (KTD9): an author must not set or change
+          # it. Load the value already on main so a hand-edited quality can be
+          # rejected before merge, keeping a self-reported tier off main and Pages.
+          import subprocess as _sp
+          _base = _sp.run(['git', 'show', 'origin/main:index.json'],
+                          capture_output=True, text=True)
+          base_quality = {}
+          if _base.returncode == 0:
+              try:
+                  base_quality = {p['name']: p.get('quality')
+                                  for p in json.loads(_base.stdout).get('packs', [])}
+              except Exception:
+                  base_quality = {}
+
           # Check version
           if data.get('version') != 1:
               errors.append(f'version must be 1, got {data.get("version")}')
@@ -86,6 +100,11 @@ jobs:
               tier = pack.get('trust_tier', '')
               if tier and tier not in VALID_TIERS:
                   errors.append(f'{prefix}: trust_tier "{tier}" not in {VALID_TIERS}')
+
+              # CI-owned quality (KTD9): reject a hand-set or changed tier.
+              q = pack.get('quality')
+              if q is not None and q != base_quality.get(name):
+                  errors.append(f'{prefix}: "quality" is set by CI and cannot be hand-edited; remove it from your entry')
 
           if errors:
               count = len(errors)

--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -713,6 +713,16 @@ jobs:
                               if not rel:
                                   continue
                               dest = os.path.join(pack_dir, rel)
+                              # Reject path-traversal members before writing. This job
+                              # runs on pull_request_target with contents:write and
+                              # extracts an unreviewed contributor tarball, so a crafted
+                              # member must not escape the temp dir (KTD11). Symlinks and
+                              # hardlinks fall through (only isdir/isfile are written).
+                              real_dest = os.path.realpath(dest)
+                              real_root = os.path.realpath(pack_dir)
+                              if real_dest != real_root and not real_dest.startswith(real_root + os.sep):
+                                  print(f"  Skipping unsafe tarball member: {m.name}")
+                                  continue
                               if m.isdir():
                                   os.makedirs(dest, exist_ok=True)
                               elif m.isfile():
@@ -1007,6 +1017,8 @@ jobs:
                   lines.append("| Bitrate | — | < 64 kbps |")
                   lines.append("| Sample rate | < 8000 Hz | < 16000 Hz |")
                   lines.append("| Duration | > 20.0s or < 0.1s | > 5.0s |")
+                  lines.append("| Pack loudness spread | — | > 15 LU |")
+                  lines.append("| Pack median loudness | — | <= -26 LUFS |")
                   lines.append("\n</details>\n")
 
               lines.append("")

--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -929,6 +929,14 @@ jobs:
                       lines.append(f"> **Error:** {qr['error']}\n")
                       continue
 
+                  # Pack-level loudness findings — these demote GOLD to SILVER.
+                  pack_warnings = qr.get('pack_warnings', [])
+                  if pack_warnings:
+                      lines.append("**Pack-level findings** — these affect the tier:\n")
+                      for pw in pack_warnings:
+                          lines.append(f"- **{pw['message']}** — {pw['detail']}")
+                      lines.append("")
+
                   # REJECTED: show all blocking issues with file details
                   if verdict == 'REJECTED' and nblocks > 0:
                       lines.append("**Blocking issues** — these must be fixed before the pack can be accepted:\n")

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ auto-save-list
 # Sublime Text
 *.sublime-workspace
 *.sublime-project
+
+# Python
+__pycache__/
+*.py[cod]

--- a/QUALITY-CHECK-ANALYSIS.md
+++ b/QUALITY-CHECK-ANALYSIS.md
@@ -1,0 +1,134 @@
+# Quality Check Analysis
+
+Methodology and calibration for the audio-quality gate in
+`.github/scripts/quality-check.py`. This document records how the pack-level
+loudness thresholds were fit from the catalog, so the values in the checker are
+evidence-based rather than guessed.
+
+## Per-file thresholds (existing)
+
+The per-file checks (true peak, integrated LUFS, leading/trailing silence,
+duration, sample rate, bitrate) were calibrated against 164 packs and ~4,500
+files when the gate first landed. Their block and warn constants live at the top
+of `quality-check.py`. This document does not re-derive them. It covers the
+pack-level loudness work added on top.
+
+## Pack-level loudness (new)
+
+The per-file gate judges each clip against absolute thresholds in isolation. A
+pack whose clips all sit inside the per-file band can still swing widely
+relative to each other and sound uneven, and a pack whose clips are uniformly
+quiet can pass every per-file check yet read as low quality. Two pack-level
+metrics close that gap:
+
+- **Loudness spread**: the range between a pack's quietest and loudest
+  measurable clip (`max - min` of integrated LUFS), in loudness units (LU).
+- **Pack median loudness**: the median integrated LUFS across a pack's
+  measurable clips, in LUFS.
+
+A clip is "measurable" when it produced a finite integrated-loudness reading and
+is at least 0.5s long. Silent clips (`-inf`), measurement failures, and clips
+under 0.5s carry no trustworthy loudness and are excluded from both metrics
+(ITU-R BS.1770 needs ~400ms to integrate). `aggregate_pack_loudness` in
+`quality-check.py` computes both. A pack with fewer than two measurable clips
+reports no spread.
+
+Both metrics are score-only. They can demote a pack from GOLD to SILVER but
+never produce REJECTED. The existing block set is unchanged.
+
+## Catalog distribution
+
+`calibrate-loudness.py` graded the full catalog with the same pipeline the gate
+uses (download the source tarball, run the per-file analysis, aggregate). 333 of
+334 packs graded across 10,823 audio files, with one (`acolyte_es`) failing to
+download.
+
+Verdict mix under the per-file gate alone: 87 GOLD, 244 SILVER, 2 REJECTED. The
+per-file checks already push most packs to SILVER, so the pack-level metrics
+mostly act on the GOLD set and on future submissions.
+
+Per-pack loudness spread (LU), n = 330 packs with >= 2 measurable clips:
+
+| min | p5 | p10 | p25 | p50 | p75 | p90 | p95 | p99 | max |
+|---|---|---|---|---|---|---|---|---|---|
+| 0.0 | 2.3 | 3.1 | 3.9 | 6.8 | 10.0 | 14.8 | 19.3 | 28.9 | 32.3 |
+
+Per-pack median loudness (LUFS), n = 332:
+
+| min | p5 | p10 | p25 | p50 | p75 | p90 | p95 | p99 | max |
+|---|---|---|---|---|---|---|---|---|---|
+| -45.2 | -30.2 | -23.7 | -21.6 | -16.8 | -14.2 | -12.5 | -11.2 | -9.0 | -7.4 |
+
+## Chosen thresholds
+
+```
+LOUDNESS_SPREAD_WARN_LU   = 15.0   # spread >= 15 LU  -> "inconsistent loudness" warn
+LOUDNESS_QUIET_PACK_LUFS  = -26.0  # median <= -26 LUFS -> "uniformly quiet" warn
+```
+
+### Spread threshold: 15.0 LU
+
+15 LU sits at roughly the 90th percentile of the catalog, well clear of the
+median (6.8) and p75 (10.0). The decisive check is how many currently-GOLD packs
+it would demote, since a poorly-fit threshold mass-mislabels the catalog:
+
+| spread threshold | GOLD packs demoted |
+|---|---|
+| >= 12 LU | 4 / 87 (4.6%) |
+| >= 14 LU | 0 / 87 |
+| >= 15 LU | 0 / 87 |
+
+No current GOLD pack has a spread of 15 LU or more. The cleanest packs are also
+the most internally consistent. So 15 LU demotes zero current GOLD packs while
+still flagging the genuinely-uneven tail (and every future submission that swings
+that wide). A 15 dB range between the quietest and loudest clip is audibly
+uneven, and the threshold gives contributors a clear target.
+
+The spread is `max - min`, which a single outlier clip can inflate. A robust
+percentile spread (p90 - p10) was considered. `max - min` was kept because the
+badge's job is to flag any audibly-jarring inconsistency, including a single
+clip far off the rest, and because the chosen threshold produces zero false
+demotions of current GOLD packs, so outlier sensitivity is not causing
+mislabeling here.
+
+### Quiet floor: -26.0 LUFS
+
+The pack-median floor catches packs that are uniformly quiet without any single
+clip tripping the per-file quiet warn (-35 LUFS). -26 LUFS is about 10 dB below
+the catalog median (-16.8) and below common streaming-loudness norms. Demotion
+impact on the GOLD set:
+
+| quiet floor | GOLD packs demoted |
+|---|---|
+| <= -22 LUFS | 18 / 87 (20.7%) |
+| <= -24 LUFS | 7 / 87 (8.0%) |
+| <= -26 LUFS | 1 / 87 (1.1%) |
+| <= -28 LUFS | 1 / 87 (1.1%) |
+
+-24 LUFS (the catalog p10) would demote 8% of GOLD packs, which over-flags
+borderline-normal packs. -26 LUFS flags the quietest tail while demoting a single
+current GOLD pack, consistent with the no-mass-mislabel requirement. The
+contributor hint points at normalizing toward roughly -16 LUFS.
+
+## Spot-checks
+
+- **arnold** (issue #97's motivating example): spread 29.6 LU, median -21.2
+  LUFS, verdict SILVER. It hits no hard block, so it grades SILVER rather than
+  REJECTED, with a wide spread. The spread warn (29.6 >= 15) now gives an
+  explicit reason it is not GOLD, which is exactly the distinction the badge
+  surfaces. The quiet warn does not fire (-21.2 > -26).
+- **acolyte_es**: download failed during calibration, so it has no measurement.
+  Transient download failures are expected across a 334-pack sweep and do not
+  affect the chosen thresholds.
+
+## Reproducing
+
+```
+python3 .github/scripts/calibrate-loudness.py --index index.json --workers 8 \
+  --output-json cal.json
+```
+
+The full catalog grades in about 7.5 minutes (1.3s per pack, 0.04s per file
+across 10,823 files with 8 workers), comfortably under the GitHub Actions 6-hour
+job ceiling. `--limit N`, `--sample N`, and `--packs name1,name2` scope smaller
+runs. The script needs ffmpeg/ffprobe and no repository write access.

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Unit tests for backfill-quality.py selection and apply logic (no ffmpeg).
+
+The grading itself needs network + ffmpeg and is smoke-tested in CI; these
+cover the resume/force-regrade selection and the non-destructive batch apply.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / ".github" / "scripts" / "backfill-quality.py"
+_spec = importlib.util.spec_from_file_location("backfill_quality", MODULE_PATH)
+bf = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bf)
+
+
+def packs():
+    return [
+        {"name": "alpha"},                          # no quality -> unreviewed
+        {"name": "beta", "quality": "unreviewed"},
+        {"name": "gamma", "quality": "gold"},       # already graded
+        {"name": "delta", "quality": "flagged"},    # already graded
+    ]
+
+
+class SelectTargetsTest(unittest.TestCase):
+    def test_default_skips_already_graded(self):
+        names = [p["name"] for p in bf.select_targets(packs())]
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_force_regrade_includes_all(self):
+        names = [p["name"] for p in bf.select_targets(packs(), force_regrade=True)]
+        self.assertEqual(names, ["alpha", "beta", "gamma", "delta"])
+
+    def test_limit_then_resume_skip(self):
+        # limit picks the first 3, then the resume skip drops graded gamma.
+        names = [p["name"] for p in bf.select_targets(packs(), limit=3)]
+        self.assertEqual(names, ["alpha", "beta"])
+
+    def test_names_filter_with_force(self):
+        names = [p["name"] for p in
+                 bf.select_targets(packs(), force_regrade=True, names=["delta", "alpha"])]
+        self.assertEqual(sorted(names), ["alpha", "delta"])
+
+
+class ApplyGradesTest(unittest.TestCase):
+    def setUp(self):
+        self.enum = ("gold", "silver", "flagged", "unreviewed")
+        self.index = {"version": 1, "packs": packs(), "total_packs": 4}
+
+    def _by_name(self):
+        return {p["name"]: p for p in self.index["packs"]}
+
+    def test_applies_counts_and_is_non_destructive(self):
+        results = [
+            {"name": "alpha", "verdict": "GOLD", "quality": "gold"},
+            {"name": "beta", "verdict": "REJECTED", "quality": "flagged"},
+        ]
+        summary = bf.apply_grades(self.index, results, self.enum)
+        self.assertEqual(summary["applied"], 2)
+        self.assertEqual(summary["flagged"], ["beta"])
+        self.assertEqual(summary["tier_counts"], {"gold": 1, "flagged": 1})
+        # AE3/R12: flagged pack stays in the index, nothing removed.
+        self.assertEqual(len(self.index["packs"]), 4)
+        self.assertEqual(self._by_name()["alpha"]["quality"], "gold")
+        self.assertEqual(self._by_name()["beta"]["quality"], "flagged")
+
+    def test_error_entries_recorded_not_applied(self):
+        results = [
+            {"name": "alpha", "error": "download failed"},
+            {"name": "beta", "verdict": "SILVER", "quality": "silver"},
+        ]
+        summary = bf.apply_grades(self.index, results, self.enum)
+        self.assertEqual(summary["errored"], ["alpha"])
+        self.assertEqual(summary["applied"], 1)
+        self.assertNotIn("quality", self._by_name()["alpha"])  # left untouched
+
+    def test_out_of_enum_recorded_as_errored(self):
+        results = [{"name": "alpha", "verdict": "?", "quality": "platinum"}]
+        summary = bf.apply_grades(self.index, results, self.enum)
+        self.assertEqual(summary["errored"], ["alpha"])
+        self.assertEqual(summary["applied"], 0)
+        self.assertNotIn("quality", self._by_name()["alpha"])
+
+    def test_idempotent_reapply_counts_but_does_not_rewrite(self):
+        results = [{"name": "gamma", "verdict": "GOLD", "quality": "gold"}]  # already gold
+        summary = bf.apply_grades(self.index, results, self.enum)
+        self.assertEqual(summary["applied"], 0)             # no change written
+        self.assertEqual(summary["tier_counts"], {"gold": 1})  # still graded
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -43,6 +43,13 @@ class SelectTargetsTest(unittest.TestCase):
                  bf.select_targets(packs(), force_regrade=True, names=["delta", "alpha"])]
         self.assertEqual(sorted(names), ["alpha", "delta"])
 
+    def test_names_filter_without_force_applies_resume_skip(self):
+        # An operator targeting an already-graded pack without --force-regrade
+        # gets a no-op (resume skip runs after the names filter), not a regrade.
+        self.assertEqual(bf.select_targets(packs(), names=["gamma"]), [])
+        names = [p["name"] for p in bf.select_targets(packs(), names=["gamma", "alpha"])]
+        self.assertEqual(names, ["alpha"])
+
 
 class ApplyGradesTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -252,6 +252,19 @@ class WritePackQualityTest(unittest.TestCase):
             _suffix_from_line(written, '"name": "beta"'),
         )
 
+    def test_entry_before_target_also_stays_byte_identical(self):
+        # Editing beta (the second entry) must leave alpha (before it) byte-
+        # identical too, not just entries after the edit.
+        qc.write_pack_quality(self.path, "beta", "gold")
+        with open(self.path, encoding="utf-8") as f:
+            written = f.read()
+        # alpha's region runs from its name line up to beta's name line.
+        def alpha_region(text):
+            start = text.index('"name": "alpha"')
+            start = text.rfind("\n", 0, start) + 1
+            return text[start:text.index('"name": "beta"')]
+        self.assertEqual(alpha_region(self.original), alpha_region(written))
+
     def test_non_ascii_survives_unescaped(self):
         qc.write_pack_quality(self.path, "alpha", "gold")
         with open(self.path, encoding="utf-8") as f:

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -113,5 +113,77 @@ class FormatPackLoudnessSummaryTest(unittest.TestCase):
         self.assertIn("spread needs >= 2", s)
 
 
+def metrics(spread, median, measured=5):
+    return {"loudness_spread": spread, "loudness_median": median, "measured_clips": measured}
+
+
+class PackLoudnessWarningsTest(unittest.TestCase):
+    def test_wide_spread_warns(self):
+        # AE1: in-band clips spanning a wide range add one pack warn.
+        warns = qc.pack_loudness_warnings(metrics(spread=20.0, median=-16.0))
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(warns[0]["key"], "inconsistent_loudness")
+
+    def test_spread_at_threshold_does_not_warn(self):
+        # Threshold uses strict >, so exactly-at-threshold is not flagged.
+        self.assertEqual(qc.pack_loudness_warnings(metrics(qc.LOUDNESS_SPREAD_WARN_LU, -16.0)), [])
+        self.assertEqual(qc.pack_loudness_warnings(metrics(qc.LOUDNESS_SPREAD_WARN_LU - 0.1, -16.0)), [])
+
+    def test_quiet_pack_warns(self):
+        # R2: a pack whose median sits at/below the floor reads as too quiet.
+        warns = qc.pack_loudness_warnings(metrics(spread=5.0, median=-27.0))
+        self.assertEqual(len(warns), 1)
+        self.assertEqual(warns[0]["key"], "uniformly_quiet")
+
+    def test_quiet_floor_is_inclusive(self):
+        # Floor uses <=, so exactly-at-floor warns; just above does not.
+        self.assertEqual(len(qc.pack_loudness_warnings(metrics(5.0, qc.LOUDNESS_QUIET_PACK_LUFS))), 1)
+        self.assertEqual(qc.pack_loudness_warnings(metrics(5.0, qc.LOUDNESS_QUIET_PACK_LUFS + 0.1)), [])
+
+    def test_clean_pack_has_no_warnings(self):
+        # GOLD happy path: consistent and loud-enough pack adds no pack warn.
+        self.assertEqual(qc.pack_loudness_warnings(metrics(spread=8.0, median=-16.0)), [])
+
+    def test_both_conditions_warn(self):
+        warns = qc.pack_loudness_warnings(metrics(spread=22.0, median=-30.0))
+        self.assertEqual({w["key"] for w in warns}, {"inconsistent_loudness", "uniformly_quiet"})
+
+    def test_no_spread_yields_no_spread_warn(self):
+        # Single measurable clip: spread is None, only the quiet check can fire.
+        self.assertEqual(qc.pack_loudness_warnings(metrics(spread=None, median=-16.0)), [])
+
+    def test_empty_metrics(self):
+        self.assertEqual(qc.pack_loudness_warnings(None), [])
+        self.assertEqual(qc.pack_loudness_warnings({}), [])
+
+    def test_demotion_message_names_measured_value_and_target(self):
+        spread_warn = qc.pack_loudness_warnings(metrics(spread=22.5, median=-16.0))[0]
+        self.assertIn("22.5", spread_warn["detail"])
+        self.assertIn("15", spread_warn["detail"])  # the GOLD target
+        quiet_warn = qc.pack_loudness_warnings(metrics(spread=5.0, median=-28.3))[0]
+        self.assertIn("-28.3", quiet_warn["detail"])
+        self.assertIn("-26", quiet_warn["detail"])  # the GOLD target
+
+
+class DecideVerdictTest(unittest.TestCase):
+    def test_clean_is_gold(self):
+        self.assertEqual(qc.decide_verdict(0, 0), "GOLD")
+
+    def test_any_warn_demotes_to_silver(self):
+        self.assertEqual(qc.decide_verdict(0, 1), "SILVER")
+
+    def test_block_forces_rejected_regardless_of_warns(self):
+        # AE2 / R5: a hard block stays REJECTED no matter how many warns exist.
+        self.assertEqual(qc.decide_verdict(1, 0), "REJECTED")
+        self.assertEqual(qc.decide_verdict(1, 99), "REJECTED")
+
+    def test_pack_warn_demotes_gold_to_silver_not_rejected(self):
+        # AE1 end to end: a wide-spread, block-free pack lands SILVER.
+        warns = len(qc.pack_loudness_warnings(metrics(spread=20.0, median=-16.0)))
+        self.assertEqual(qc.decide_verdict(0, warns), "SILVER")
+        # AE2: the same pack with a hard block is still REJECTED.
+        self.assertEqual(qc.decide_verdict(1, warns), "REJECTED")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -12,6 +12,8 @@ Run from the repo root:
 """
 
 import importlib.util
+import os
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -183,6 +185,123 @@ class DecideVerdictTest(unittest.TestCase):
         self.assertEqual(qc.decide_verdict(0, warns), "SILVER")
         # AE2: the same pack with a hard block is still REJECTED.
         self.assertEqual(qc.decide_verdict(1, warns), "REJECTED")
+
+
+class VerdictToQualityTest(unittest.TestCase):
+    def test_mapping_is_exact_lowercase(self):
+        # Casing matters: a stray "GOLD" would pass the site's !== "flagged"
+        # filter yet render no badge, undetected.
+        self.assertEqual(qc.verdict_to_quality("GOLD"), "gold")
+        self.assertEqual(qc.verdict_to_quality("SILVER"), "silver")
+        self.assertEqual(qc.verdict_to_quality("REJECTED"), "flagged")
+
+    def test_unknown_or_missing_maps_to_unreviewed(self):
+        self.assertEqual(qc.verdict_to_quality(None), "unreviewed")
+        self.assertEqual(qc.verdict_to_quality(""), "unreviewed")
+        self.assertEqual(qc.verdict_to_quality("WHATEVER"), "unreviewed")
+
+
+def _fixture_index():
+    # Two entries; alpha carries a non-ASCII (u-umlaut + em-dash) description,
+    # beta is the untouched control. alpha precedes beta so any change to alpha
+    # leaves beta's bytes downstream unchanged.
+    return {
+        "version": 1,
+        "packs": [
+            {"name": "alpha", "display_name": "Alpha",
+             "description": "Crüsader — scheming monastery lord"},
+            {"name": "beta", "display_name": "Beta", "description": "beta plain desc",
+             "quality": "silver"},
+        ],
+        "total_packs": 2,
+    }
+
+
+def _suffix_from_line(text, needle):
+    i = text.index(needle)
+    line_start = text.rfind("\n", 0, i) + 1
+    return text[line_start:]
+
+
+class WritePackQualityTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp(prefix="idx-test-")
+        self.path = os.path.join(self.dir, "index.json")
+        self.original = qc.serialize_index(_fixture_index())
+        with open(self.path, "w", encoding="utf-8") as f:
+            f.write(self.original)
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.dir, ignore_errors=True)
+
+    def test_writes_target_entry(self):
+        changed = qc.write_pack_quality(self.path, "alpha", "gold")
+        self.assertTrue(changed)
+        with open(self.path, encoding="utf-8") as f:
+            written = f.read()
+        self.assertEqual(written, qc.serialize_index(_set(_fixture_index(), "alpha", "gold")))
+
+    def test_other_entries_stay_byte_identical(self):
+        qc.write_pack_quality(self.path, "alpha", "gold")
+        with open(self.path, encoding="utf-8") as f:
+            written = f.read()
+        # beta's entry (from its name line through EOF) is unchanged byte for byte.
+        self.assertEqual(
+            _suffix_from_line(self.original, '"name": "beta"'),
+            _suffix_from_line(written, '"name": "beta"'),
+        )
+
+    def test_non_ascii_survives_unescaped(self):
+        qc.write_pack_quality(self.path, "alpha", "gold")
+        with open(self.path, encoding="utf-8") as f:
+            written = f.read()
+        self.assertIn("Crüsader — scheming monastery lord", written)
+        self.assertNotIn("\\u00fc", written)  # not escaped to ASCII
+
+    def test_idempotent_rewrite_is_noop(self):
+        qc.write_pack_quality(self.path, "beta", "silver")  # already silver
+        with open(self.path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), self.original)
+        # A real change reports True, a repeat reports False.
+        self.assertTrue(qc.write_pack_quality(self.path, "alpha", "gold"))
+        self.assertFalse(qc.write_pack_quality(self.path, "alpha", "gold"))
+
+    def test_out_of_enum_value_raises_before_writing(self):
+        with self.assertRaises(ValueError):
+            qc.write_pack_quality(self.path, "alpha", "platinum")
+        with open(self.path, encoding="utf-8") as f:
+            self.assertEqual(f.read(), self.original)  # file untouched
+
+    def test_missing_pack_raises(self):
+        with self.assertRaises(KeyError):
+            qc.write_pack_quality(self.path, "nonexistent", "gold")
+
+
+def _set(index_data, name, quality):
+    qc.set_entry_quality(index_data, name, quality)
+    return index_data
+
+
+class TarballPathGuardTest(unittest.TestCase):
+    def test_in_bounds_paths_allowed(self):
+        base = tempfile.mkdtemp(prefix="tar-test-")
+        try:
+            self.assertTrue(qc._is_within_directory(base, os.path.join(base, "sounds/a.mp3")))
+            self.assertTrue(qc._is_within_directory(base, base))
+        finally:
+            import shutil
+            shutil.rmtree(base, ignore_errors=True)
+
+    def test_traversal_paths_rejected(self):
+        base = tempfile.mkdtemp(prefix="tar-test-")
+        try:
+            self.assertFalse(qc._is_within_directory(base, os.path.join(base, "../evil")))
+            self.assertFalse(qc._is_within_directory(base, os.path.join(base, "a/../../evil")))
+            self.assertFalse(qc._is_within_directory(base, "/etc/passwd"))
+        finally:
+            import shutil
+            shutil.rmtree(base, ignore_errors=True)
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_check.py
+++ b/tests/test_quality_check.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Unit tests for quality-check.py pack-level loudness aggregation.
+
+Stdlib `unittest` only — the registry ships no pip dependencies. The checker
+lives at .github/scripts/quality-check.py (hyphen + dotted path, not importable
+by name), so it is loaded by path with importlib.
+
+Run from the repo root:
+  python3 -m unittest discover tests
+  # or
+  python3 tests/test_quality_check.py
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / ".github" / "scripts" / "quality-check.py"
+_spec = importlib.util.spec_from_file_location("quality_check", MODULE_PATH)
+qc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(qc)
+
+
+def file_result(lufs="absent", duration=1.0):
+    """Build a classify_file-shaped result for the aggregation under test.
+
+    lufs="absent" omits the key entirely (loudnorm failure); pass "-inf",
+    float("-inf"), or a number to model the other cases. duration=None omits
+    the duration (probe failure).
+    """
+    stats = {}
+    if duration is not None:
+        stats["duration"] = duration
+    if lufs != "absent":
+        stats["lufs"] = lufs
+    return {"file": "clip.mp3", "blocks": [], "warns": [], "stats": stats}
+
+
+class AggregatePackLoudnessTest(unittest.TestCase):
+    def test_happy_path_spread_and_median(self):
+        results = [file_result(-20.0), file_result(-23.0), file_result(-26.0)]
+        m = qc.aggregate_pack_loudness(results)
+        self.assertEqual(m["loudness_spread"], 6.0)   # -20 − (-26)
+        self.assertEqual(m["loudness_median"], -23.0)
+        self.assertEqual(m["measured_clips"], 3)
+
+    def test_excludes_absent_inf_and_short_clips(self):
+        results = [
+            file_result(-20.0),                  # measurable
+            file_result(-30.0),                  # measurable
+            file_result("absent"),               # loudnorm failed -> excluded
+            file_result("-inf"),                 # silent -> excluded
+            file_result(-25.0, duration=0.3),    # too short -> excluded though finite
+            file_result(-25.0, duration=None),   # probe failed -> excluded
+        ]
+        m = qc.aggregate_pack_loudness(results)
+        self.assertEqual(m["measured_clips"], 2)
+        self.assertEqual(m["loudness_spread"], 10.0)   # -20 − (-30)
+        self.assertEqual(m["loudness_median"], -25.0)
+
+    def test_inf_as_float_is_excluded(self):
+        # Defensive: a raw float('-inf'), not just the "-inf" string, is excluded.
+        results = [file_result(-20.0), file_result(float("-inf")), file_result(-24.0)]
+        m = qc.aggregate_pack_loudness(results)
+        self.assertEqual(m["measured_clips"], 2)
+        self.assertEqual(m["loudness_spread"], 4.0)
+        self.assertEqual(m["loudness_median"], -22.0)
+
+    def test_fewer_than_two_measurable_yields_no_spread(self):
+        results = [file_result(-20.0), file_result("-inf"), file_result("absent")]
+        m = qc.aggregate_pack_loudness(results)
+        self.assertIsNone(m["loudness_spread"])
+        self.assertEqual(m["loudness_median"], -20.0)
+        self.assertEqual(m["measured_clips"], 1)
+
+    def test_single_clip_has_median_no_spread(self):
+        m = qc.aggregate_pack_loudness([file_result(-18.0)])
+        self.assertIsNone(m["loudness_spread"])
+        self.assertEqual(m["loudness_median"], -18.0)
+        self.assertEqual(m["measured_clips"], 1)
+
+    def test_no_measurable_clips_does_not_error(self):
+        m = qc.aggregate_pack_loudness([file_result("-inf"), file_result("absent")])
+        self.assertIsNone(m["loudness_spread"])
+        self.assertIsNone(m["loudness_median"])
+        self.assertEqual(m["measured_clips"], 0)
+
+    def test_empty_input(self):
+        m = qc.aggregate_pack_loudness([])
+        self.assertEqual(
+            m, {"loudness_spread": None, "loudness_median": None, "measured_clips": 0}
+        )
+
+
+class FormatPackLoudnessSummaryTest(unittest.TestCase):
+    def test_none_when_no_measurable_clips(self):
+        self.assertIsNone(qc.format_pack_loudness_summary(None))
+        self.assertIsNone(qc.format_pack_loudness_summary(
+            {"loudness_spread": None, "loudness_median": None, "measured_clips": 0}))
+
+    def test_spread_and_median_phrasing(self):
+        s = qc.format_pack_loudness_summary(
+            {"loudness_spread": 6.0, "loudness_median": -23.0, "measured_clips": 3})
+        self.assertIn("spread 6.0 LU", s)
+        self.assertIn("median -23.0 LUFS", s)
+        self.assertIn("3 measurable clips", s)
+
+    def test_single_clip_phrasing_omits_spread_figure(self):
+        s = qc.format_pack_loudness_summary(
+            {"loudness_spread": None, "loudness_median": -18.0, "measured_clips": 1})
+        self.assertIn("median -18.0 LUFS", s)
+        self.assertIn("1 measurable clip", s)
+        self.assertIn("spread needs >= 2", s)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this does

The audio gate grades each clip in isolation and emits GOLD/SILVER/REJECTED, but two gaps remain: a pack whose clips each sit in-band can still swing 20+ LU and sound uneven, and the verdict is never written to `index.json` or shown to anyone. This PR adds pack-level loudness scoring, persists the tier on merge, and backfills the catalog so every listed pack carries a tier. The site PR (PeonPing/openpeon) renders it as a badge.

## What changed

- **Measurement** (`quality-check.py`): `aggregate_pack_loudness` computes loudness spread (max minus min of in-band clips) and median LUFS, excluding silent, sub-0.5s, and failed clips. Pure function, unit-tested without ffmpeg.
- **Score-only demotion**: spread `>= 15 LU` or median `<= -26 LUFS` adds a warn (GOLD to SILVER only, never REJECTED). The existing block set is unchanged. The PR comment names the measured value and the target so an author can close the gap.
- **Persistence** (`persist-quality.yml`): on merge the changed pack is re-graded and its `quality` written back surgically. Only that entry changes, re-serialized to stay byte-identical, schema-validated before commit, serialized under a no-cancel concurrency group, with the Vercel deploy hook re-fired.
- **Backfill** (`backfill-quality.yml` plus `backfill-quality.py`): a manual `workflow_dispatch` that grades every pack and opens a PR for maintainer review, listing flagged packs without ever auto-removing them. `--force-regrade` re-grades after a threshold change.
- **Hardening**: the inline tarball extraction in `validate-index.yml` now rejects path-traversal members.

## Calibration

Thresholds were fit from the catalog's distribution before they affect any tier. `calibrate-loudness.py` graded all 334 packs, with the full distribution in `QUALITY-CHECK-ANALYSIS.md`. Both clear the current GOLD set:

- Spread `>= 15 LU` (the catalog p90): demotes 0 of 87 GOLD packs.
- Median `<= -26 LUFS`: demotes 1 of 87.

`arnold` (issue #97) grades SILVER on a 29.6 LU spread, now with an explicit reason it is not GOLD.

## Tests

41 stdlib `unittest` tests, no new dependencies: `python3 -m unittest discover tests`. They cover the aggregation edge cases, the verdict-to-quality mapping casing, write-back byte-stability against a non-ASCII fixture, and idempotent re-runs.

## Known follow-ups (from code review)

Both are plan-acknowledged and degrade gracefully.

1. **Persist re-grades the mutable `source_ref` rather than the reviewed SHA** (a TOCTOU gap). `--source-ref` exists on the script but is not passed, so an author could swap content between review and the post-merge grade. The blast radius stays a GOLD/SILVER mislabel, since extraction is traversal-guarded and there is no code-execution path. Worth pinning to the reviewed SHA before relying on persist at scale.
2. **Changed-pack detection diffs only the prior commit** (`HEAD~1`). A coalesced auto-merge run or a multi-commit push can leave a pack `unreviewed` until its next change or the next backfill. The real fix is a last-persisted-SHA cursor or a serial queue.

## Operational prerequisites

- **Branch protection on `main`**: the persist job pushes to `main`, so the `github-actions` bot needs push rights or a `PERSIST_TOKEN` PAT with bypass. It fails loudly otherwise. Worth deciding before merge, since persist is inert until this is set.
- **`VERCEL_DEPLOY_HOOK`**: already present. The persist job POSTs it so the badge appears without the 24h revalidate wait.
- **Backfill is manual**: run with the `limit` input first to smoke a sample and measure runtime (about 7.5 minutes locally, CI unverified). Couple it with the site badge PR so no listed pack shows blank at launch.
