### PR TITLE
Add Yamanote Sounds pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -13199,6 +13199,46 @@
             "updated": "2026-03-24"
         },
         {
+            "name": "yamanote-sounds",
+            "display_name": "Yamanote Sounds",
+            "version": "1.0.0",
+            "description": "Tokyo Yamanote Line departure melodies — all 30 stations — with a kawaii E235 train mascot icon for every event state.",
+            "author": {
+                "name": "Skyforce77",
+                "github": "skyforce77"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 28,
+            "total_size_bytes": 6129262,
+            "source_repo": "skyforce77/open-peon-yamanote-sounds",
+            "source_ref": "1792837be5ee0fd05a244d8a1f5acc9a371440f5",
+            "source_path": ".",
+            "manifest_sha256": "72b2c6cb40278fab415dcd8c6735bbe50f8a37b42f8f232c97cac7ffec399a1d",
+            "tags": [
+                "trains",
+                "japan",
+                "yamanote"
+            ],
+            "preview_sounds": [
+                "sounds/yamanote_astroboy.mp3",
+                "sounds/yamanote_ebisu.mp3"
+            ],
+            "added": "2026-06-17",
+            "updated": "2026-06-17"
+        },
+        {
             "name": "yasuo-pack",
             "display_name": "Yasuo(亚索)",
             "version": "1.1.0",
@@ -13568,5 +13608,5 @@
             "updated": "2026-04-17"
         }
     ],
-    "total_packs": 335
+    "total_packs": 338
 }


### PR DESCRIPTION
## Add: Yamanote Sounds (`yamanote-sounds`)

A Tokyo **Yamanote Line** sound pack: the authentic departure melody (発車メロディ) of **all 30 stations**, mapped to the event lifecycle, with a **kawaii E235 train mascot** icon for every event state (CESP per-category icons).

- **`task.acknowledge`** cycles the full loop — Tokyo, Kanda, … — including the iconic **Astro Boy** (Takadanobaba) and **The Third Man** (Ebisu).
- Repo: https://github.com/skyforce77/open-peon-yamanote-sounds
- Source ref pinned to an immutable commit (`1792837`); `manifest_sha256` verified against GitHub raw.

### Pre-flight (ran the CI gates locally)
- **Schema:** valid, alphabetical order preserved (between `wrecking_ball` and `yasuo-pack`).
- **Category coverage:** all 6 core categories populated.
- **Audio quality (`quality-check.py`):** **SILVER — 0 blocking issues** (leading/trailing silence trimmed from every clip).
- **Manifest SHA256:** matches the file served at the pinned ref.

### Licensing
`license: "fair-use"` — the melodies are JR East / composer copyrighted departure jingles; this is an unofficial, non-commercial fan pack (same basis as the existing `japan-rail` entry it forks from).
