### PR TITLE
Update Yamanote Sounds to v1.0.1 (compliance pass)

### DIFF
--- a/index.json
+++ b/index.json
@@ -13201,7 +13201,7 @@
         {
             "name": "yamanote-sounds",
             "display_name": "Yamanote Sounds",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "description": "Tokyo Yamanote Line departure melodies — all 30 stations — with a kawaii E235 train mascot icon for every event state.",
             "author": {
                 "name": "Skyforce77",
@@ -13220,12 +13220,12 @@
             ],
             "language": "en",
             "license": "fair-use",
-            "sound_count": 28,
-            "total_size_bytes": 6129262,
+            "sound_count": 30,
+            "total_size_bytes": 6185932,
             "source_repo": "skyforce77/open-peon-yamanote-sounds",
-            "source_ref": "1792837be5ee0fd05a244d8a1f5acc9a371440f5",
+            "source_ref": "v1.0.1",
             "source_path": ".",
-            "manifest_sha256": "72b2c6cb40278fab415dcd8c6735bbe50f8a37b42f8f232c97cac7ffec399a1d",
+            "manifest_sha256": "c6e4bf30cda637fe1eb38b38f122c27fa74535d176d2661e6180fd183ea02ec2",
             "tags": [
                 "trains",
                 "japan",


### PR DESCRIPTION
## Update: Yamanote Sounds → v1.0.1 (compliance pass)

Addresses every actionable warning from the v1.0.0 review while keeping the pack SILVER.

- **Icons** resized 1024→512px — all now **well under the 500 KB** limit (was ~1.9 MB each).
- **Audio normalized** (`loudnorm I=-16 TP=-1.5`) — clears all *"volume is very high"* warnings.
- **Silence trimmed at −35 dB** (matching the checker) — clears **all dead-air warnings**.
- **Thin core categories fixed** — `task.error` and `resource.limit` now have **2 sounds** each.
- Source ref now points to the **`v1.0.1` tag**; `manifest_sha256` re-verified against GitHub raw.

Remaining warnings are only *"long for a notification sound"* — inherent to authentic departure melodies (8–18 s) and not fixable without truncating the tunes. Local `quality-check.py`: **SILVER, 0 blocks**.
