### PR TITLE
Add producer_tags community pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -8014,6 +8014,46 @@
             "quality": "silver"
         },
         {
+            "name": "producer_tags",
+            "display_name": "Hip-Hop Producer Tags",
+            "version": "1.0.0",
+            "description": "Iconic hip-hop producer drops mapped to coding events. Metro Boomin, DJ Mustard, Wheezy, Jetsonmade, Quay Global, 808 Mafia, Take a Daytrip, and Benny X.",
+            "author": {
+                "name": "Gary Sheng",
+                "github": "garysheng"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 9,
+            "total_size_bytes": 334609,
+            "source_repo": "garysheng/peonping-producer-tags",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "bdcddbf4700c43cb1f898a02f6d4e041ba294cd511fca535927ce188c26ff103",
+            "tags": [
+                "hip-hop",
+                "rap",
+                "producer-tags",
+                "music",
+                "meme"
+            ],
+            "preview_sounds": [
+                "metro_boomin_want_some_more.mp3",
+                "jetson_made_another_one.mp3"
+            ],
+            "added": "2026-06-24",
+            "updated": "2026-06-24"
+        },
+        {
             "name": "professor-layton",
             "display_name": "Professor Layton",
             "version": "1.0.0",
@@ -13947,5 +13987,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 338
+    "total_packs": 339
 }


### PR DESCRIPTION
Adds the **Hip-Hop Producer Tags** community pack.

9 iconic producer drops cut from a single compilation, silence-segmented, loudness-normalized, and trimmed tight — mapped onto CESP coding events.

| Producer | Fires on |
|---|---|
| Metro Boomin — "want some more" | session.start / input.required |
| 808 Mafia | session.start / resource.limit |
| DJ Mustard | task.acknowledge |
| Quay Global | task.acknowledge |
| Jetsonmade | task.complete |
| Wheezy | task.complete |
| Take a Daytrip | task.complete |
| Metro Boomin — "if Young Metro don't trust you" | task.error / resource.limit |
| Benny X | task.error / input.required |

- **Source:** [garysheng/peonping-producer-tags](https://github.com/garysheng/peonping-producer-tags) @ `v1.0.0`
- **trust_tier:** community
- **license:** fair-use (short producer-identifier drops, personal/non-commercial)
- Entry validates against `schema/registry-v1.schema.json` (`$defs/pack`); inserted in alpha order between `postal2_pl` and `professor-layton`; `total_packs` bumped to 339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)