### PR TITLE
Add stojan zajebancije pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -11002,6 +11002,42 @@
             "quality": "silver"
         },
         {
+            "name": "stojan-zajebancije-pack",
+            "display_name": "Stojan zajebancije",
+            "version": "1.0.0",
+            "description": "Pack with famous Serbian prank calls",
+            "author": {
+                "name": "KornjacaRadee",
+                "github": "KornjacaRadee"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.complete",
+                "task.error",
+                "input.required"
+            ],
+            "language": "sr",
+            "license": "MIT",
+            "sound_count": 4,
+            "total_size_bytes": 216854,
+            "source_repo": "KornjacaRadee/peonping-stojan-zajebancije-soundpack",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "87b9115daa1455e63eec09315271968a25429e78ca1b2b21a50e5cfd0c59c476",
+            "tags": [
+                "prank",
+                "serbian",
+                "funny"
+            ],
+            "preview_sounds": [
+                "greeting.mp3",
+                "done.mp3"
+            ],
+            "added": "2026-06-25",
+            "updated": "2026-06-25"
+        },
+        {
             "name": "storm-spirit",
             "display_name": "Storm Spirit (Dota 2)",
             "version": "1.0.0",

--- a/index.json
+++ b/index.json
@@ -11004,7 +11004,7 @@
         {
             "name": "stojan-zajebancije-pack",
             "display_name": "Stojan zajebancije",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "description": "Pack with famous Serbian prank calls",
             "author": {
                 "name": "KornjacaRadee",
@@ -11013,18 +11013,20 @@
             "trust_tier": "community",
             "categories": [
                 "session.start",
+                "task.acknowledge",
                 "task.complete",
                 "task.error",
-                "input.required"
+                "input.required",
+                "resource.limit"
             ],
             "language": "sr",
             "license": "MIT",
             "sound_count": 4,
-            "total_size_bytes": 216854,
+            "total_size_bytes": 249113,
             "source_repo": "KornjacaRadee/peonping-stojan-zajebancije-soundpack",
             "source_ref": "v1.0.0",
             "source_path": ".",
-            "manifest_sha256": "87b9115daa1455e63eec09315271968a25429e78ca1b2b21a50e5cfd0c59c476",
+            "manifest_sha256": "bce92209e93081b7c7e4a6e7d6e26ac6fee82bc34b6e4da57b68fc5d2316b062",
             "tags": [
                 "prank",
                 "serbian",

--- a/index.json
+++ b/index.json
@@ -11024,7 +11024,7 @@
             "sound_count": 4,
             "total_size_bytes": 249113,
             "source_repo": "KornjacaRadee/peonping-stojan-zajebancije-soundpack",
-            "source_ref": "v1.0.0",
+            "source_ref": "v1.0.1",
             "source_path": ".",
             "manifest_sha256": "bce92209e93081b7c7e4a6e7d6e26ac6fee82bc34b6e4da57b68fc5d2316b062",
             "tags": [


### PR DESCRIPTION
Adds stojan-zajebancije-pack, a Serbian OpenPeon/CESP sound pack.

Pack details:

Source repo: KornjacaRadee/peonping-stojan-zajebancije-soundpack
Version: 1.0.0
Source ref: v1.0.0
Language: sr
License: MIT
Categories:
session.start
task.complete
task.error
input.required
Sound count: 4
Total size: 216854 bytes
Tags: prank, serbian, funny

I added the pack entry to index.json and kept the registry entry sorted alphabetically by name.