### PR TITLE
Add anime-girls community pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -620,6 +620,46 @@
             "quality": "silver"
         },
         {
+            "name": "anime-girls",
+            "display_name": "Anime Girls",
+            "version": "1.1.0",
+            "description": "Cute anime girl voice clips as coding event notifications",
+            "author": {
+                "name": "Michael Malura",
+                "github": "maluramichael"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "ja",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 16,
+            "total_size_bytes": 511146,
+            "source_repo": "maluramichael/openpeon-anime-girls",
+            "source_ref": "v1.1.0",
+            "source_path": ".",
+            "manifest_sha256": "a2e201c30c4103d46c5c545d61470cf02eedb36da845da2ead4cfc9b95fbd722",
+            "tags": [
+                "anime",
+                "voice",
+                "japanese"
+            ],
+            "preview_sounds": [
+                "yatta.mp3",
+                "ano_ne.mp3"
+            ],
+            "added": "2026-06-29",
+            "updated": "2026-06-29"
+        },
+        {
             "name": "anran",
             "display_name": "Overwatch - Anran",
             "version": "1.0.0",
@@ -14149,5 +14189,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 343
+    "total_packs": 344
 }


### PR DESCRIPTION
Adds the **Anime Girls** community pack — short, cute anime girl voice clips mapped onto the full CESP event lifecycle.

- **16 clips** covering **all 6 core categories** (+ `session.end`, `user.spam`). `task.complete` → Yatta/Ara-ara/Sugoi, `task.error` → Baka/Yada/Ittai, `resource.limit` → Yamette/explosion, `input.required` → Ano ne, `session.start` → Itadakimasu/Onii-chan, etc.
- **Source:** [maluramichael/openpeon-anime-girls](https://github.com/maluramichael/openpeon-anime-girls) @ `v1.1.0`
- **trust_tier:** community · **license:** CC-BY-NC-4.0 · **language:** ja
- Entry validates against `schema/registry-v1.schema.json` (`$defs/pack`); inserted in alpha order between `anchorman_news_team` and `anran`; `total_packs` bumped.

### Pre-flight (ran the CI gates locally)
- **Schema:** valid, alphabetical order preserved, `quality` field omitted (CI-owned).
- **Category coverage:** all 6 core categories populated, 16 unique sounds (≥6 minimum).
- **Audio quality (`quality-check.py`):** **SILVER — 0 blocking issues** (loudness-spread / high-volume warnings only).
- **Manifest SHA256:** `a2e201c3…d722` verified against the raw `openpeon.json` served at the pinned `v1.1.0` ref.

### Licensing
Unofficial, non-commercial fan pack; clips belong to their respective owners.