### PR TITLE
Add diablo-drops community pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -2428,6 +2428,48 @@
             "quality": "gold"
         },
         {
+            "name": "diablo-drops",
+            "display_name": "Diablo II Loot Sounds",
+            "version": "1.0.0",
+            "description": "Classic Diablo II loot filter sounds (rune, gem, gold drops and more) as coding event notifications",
+            "author": {
+                "name": "Michael Malura",
+                "github": "maluramichael"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 18,
+            "total_size_bytes": 829254,
+            "source_repo": "maluramichael/openpeon-diablo-drops",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "3ddf3cdea53e1c15b9fae780ce99837a23f0602f237471a6504e21dda95d18ad",
+            "tags": [
+                "gaming",
+                "diablo",
+                "arpg",
+                "blizzard"
+            ],
+            "preview_sounds": [
+                "rune.wav",
+                "gold.wav"
+            ],
+            "added": "2026-06-29",
+            "updated": "2026-06-29"
+        },
+        {
             "name": "djkhaled",
             "display_name": "DJ Khaled",
             "version": "1.0.0",
@@ -14107,5 +14149,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 342
+    "total_packs": 343
 }


### PR DESCRIPTION
Adds the **Diablo II Loot Sounds** community pack — the classic Diablo II loot-filter drop sounds mapped onto the full CESP event lifecycle.

- **18 clips** covering **all 9 categories**. `task.complete` cycles seven iconic drops (rune, gem, jewel, gold, amulet, ring, rare); `session.start` → enter/teleport, `task.error` → hostile/stun, `resource.limit` → out-of-potions, `session.end` → quest complete, etc.
- **Source:** [maluramichael/openpeon-diablo-drops](https://github.com/maluramichael/openpeon-diablo-drops) @ `v1.0.0`
- **trust_tier:** community · **license:** CC-BY-NC-4.0 · **language:** en
- Entry validates against `schema/registry-v1.schema.json` (`$defs/pack`); inserted in alpha order between `deep-dive-banter` and `djkhaled`; `total_packs` bumped to 343.

### Pre-flight (ran the CI gates locally)
- **Schema:** valid, alphabetical order preserved, `quality` field omitted (CI-owned).
- **Audio quality (`quality-check.py`):** **SILVER — 0 blocking issues** (high-volume / trailing-silence warnings only).
- **Manifest SHA256:** `3ddf3cde…d18ad` verified against the raw `openpeon.json` served at the pinned `v1.0.0` ref.

### Licensing
`license: "CC-BY-NC-4.0"` on the manifest; the underlying sound effects are © Blizzard Entertainment, included as an unofficial, non-commercial fan pack (same fair-use basis as other game-derived packs in the registry).