### PR TITLE
Add Vulcan sound pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -12872,7 +12872,7 @@
             ],
             "language": "en",
             "license": "CC-BY-NC-4.0",
-            "sound_count": 37,
+            "sound_count": 36,
             "total_size_bytes": 4215267,
             "source_repo": "joshuadavidthomas/openpeon-vulcan",
             "source_ref": "v1.0.0",
@@ -12889,8 +12889,7 @@
                 "smack-my-huge-iron-buttocks.mp3"
             ],
             "added": "2026-07-17",
-            "updated": "2026-07-17",
-            "quality": "unreviewed"
+            "updated": "2026-07-17"
         },
         {
             "name": "warcraft-peon",

--- a/index.json
+++ b/index.json
@@ -12850,6 +12850,49 @@
             "quality": "silver"
         },
         {
+            "name": "vulcan",
+            "display_name": "Vulcan",
+            "version": "1.0.0",
+            "description": "A coding spin on Birmingham's imaginary talking Vulcan statue, delivering forecasts, bad jokes, and trivia in a booming baritone.",
+            "author": {
+                "name": "Josh Thomas",
+                "github": "joshuadavidthomas"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 37,
+            "total_size_bytes": 4215267,
+            "source_repo": "joshuadavidthomas/openpeon-vulcan",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "68bf1f3c6f1ef19c57e7a319581a4580adbf6bb0a8e575f9234197c76a1d5ed2",
+            "tags": [
+                "comedy",
+                "birmingham",
+                "radio",
+                "vulcan"
+            ],
+            "preview_sounds": [
+                "good-morning-coder-good-morning-computer.mp3",
+                "smack-my-huge-iron-buttocks.mp3"
+            ],
+            "added": "2026-07-17",
+            "updated": "2026-07-17",
+            "quality": "unreviewed"
+        },
+        {
             "name": "warcraft-peon",
             "display_name": "Warcraft 3 Peon",
             "version": "1.0.0",


### PR DESCRIPTION
## Summary

- add the Vulcan sound pack to the registry
- register all nine supported event categories and 37 sound entries
- pin the source to the new v1.0.0 tag and verified manifest hash

## Validation

- `python -m pytest` (43 passed)