### PR TITLE
Add stellaris_evil_corp_advisor pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -11287,8 +11287,8 @@
             "quality": "silver"
         },
         {
-            "name": "stellaris-advisor",
-            "display_name": "Stellaris Advisor",
+            "name": "stellaris_evil_corp_advisor",
+            "display_name": "Stellaris Evil Corp Advisor",
             "version": "1.0.0",
             "description": "Alien-empire advisor notification voice lines for Claude Code session events.",
             "author": {
@@ -11311,7 +11311,7 @@
             "source_repo": "cohanna/peonping-stellaris-advisor",
             "source_ref": "v1.0.0",
             "source_path": ".",
-            "manifest_sha256": "8ccacd738ddbfb183ce46b622b70df7097323c4266d7fb03877183369ede7529",
+            "manifest_sha256": "6ea07dd146cac8cff88abbed81a67a65caf91a17a187429d998a4ac9e2be1453",
             "tags": [
                 "gaming",
                 "stellaris",

--- a/index.json
+++ b/index.json
@@ -11287,6 +11287,47 @@
             "quality": "silver"
         },
         {
+            "name": "stellaris-advisor",
+            "display_name": "Stellaris Advisor",
+            "version": "1.0.0",
+            "description": "Alien-empire advisor notification voice lines for Claude Code session events.",
+            "author": {
+                "name": "clinux",
+                "github": "cohanna"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 52,
+            "total_size_bytes": 12653166,
+            "source_repo": "cohanna/peonping-stellaris-advisor",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "8ccacd738ddbfb183ce46b622b70df7097323c4266d7fb03877183369ede7529",
+            "tags": [
+                "gaming",
+                "stellaris",
+                "sci-fi",
+                "space",
+                "strategy",
+                "paradox"
+            ],
+            "preview_sounds": [
+                "advisor_generic_phrase_02.wav",
+                "advisor_notification_colony_established_01.wav"
+            ],
+            "added": "2026-07-20",
+            "updated": "2026-07-20"
+        },
+        {
             "name": "stojan-zajebancije-pack",
             "display_name": "Stojan zajebancije",
             "version": "1.0.1",


### PR DESCRIPTION
## Summary
- Adds `stellaris_evil_corp_advisor`, a 52-line OpenPeon pack of Stellaris advisor voice notifications across 6 categories (session.start, task.complete, task.error, task.acknowledge, input.required, resource.limit).
- Source repo: https://github.com/cohanna/peonping-stellaris-advisor, tagged v1.0.0.

## Checklist
- [x] Pack repo is public with `openpeon.json` + `sounds/` at root, tagged `v1.0.0`
- [x] All audio files ≤ 1 MB, total pack size ~12 MB (well under 50 MB)
- [x] `manifest_sha256` computed from the LF-normalized manifest on GitHub
- [x] Entry inserted alphabetically by `name` in `index.json`, `trust_tier: community`
- [x] Verified `index.json` remains valid JSON, fully sorted, no duplicate names

🤖 Generated with [Claude Code](https://claude.com/claude-code)