### PR TITLE
Add wh40k-dow-chaplain (Warhammer 40k Dawn of War Chaplain)

### DIFF
--- a/index.json
+++ b/index.json
@@ -13685,6 +13685,47 @@
             "quality": "gold"
         },
         {
+            "name": "wh40k-dow-chaplain",
+            "display_name": "Warhammer 40k Dawn of War Chaplain",
+            "version": "1.0.0",
+            "description": "Warhammer 40k Dawn of War Chaplain sound pack for coding events.",
+            "author": {
+                "name": "Hamidhasan Ahmed",
+                "github": "Hamidhasan"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 31,
+            "total_size_bytes": 8827592,
+            "source_repo": "Hamidhasan/openpeon-wh40k-chaplain",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "c9ebea21cfeb627f9ac5162142825fd45e755331999e6f15ea3457310f362813",
+            "tags": [
+                "gaming",
+                "wh40k",
+                "dawn-of-war"
+            ],
+            "preview_sounds": [
+                "ChaplainBuilt.wav",
+                "ChaplainVictory3.wav"
+            ],
+            "added": "2026-07-26",
+            "updated": "2026-07-26"
+        },
+        {
             "name": "widowmaker",
             "display_name": "Overwatch - Widowmaker",
             "version": "1.0.0",


### PR DESCRIPTION
## Summary

Adds the **Warhammer 40k Dawn of War Chaplain** sound pack to the registry — 31 sounds across 9 categories featuring voice lines from the Space Marine Chaplain unit.

## Details

- **Pack name**: `wh40k-dow-chaplain`
- **Display name**: Warhammer 40k Dawn of War Chaplain
- **Author**: [Hamidhasan](https://github.com/Hamidhasan)
- **Source**: [Hamidhasan/openpeon-wh40k-chaplain](https://github.com/Hamidhasan/openpeon-wh40k-chaplain)
- **Sound count**: 31
- **License**: CC-BY-NC-4.0
- **Categories**: all 9 core + extended
- **Source ref**: `v1.0.0`