### PR TITLE
Add postal-dude and postal-dude-clean packs

### DIFF
--- a/index.json
+++ b/index.json
@@ -8295,6 +8295,94 @@
             "quality": "gold"
         },
         {
+            "name": "postal-dude",
+            "display_name": "Postal Dude (POSTAL 2)",
+            "version": "1.0.0",
+            "description": "The Postal Dude from POSTAL 2 reacts to your coding session. Uncensored.",
+            "author": {
+                "name": "dmonteoliva",
+                "github": "dmonteoliva"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 62,
+            "total_size_bytes": 1128914,
+            "source_repo": "dmonteoliva/openpeon-postal-dude",
+            "source_ref": "v1.0.0",
+            "source_path": "postal-dude",
+            "manifest_sha256": "6c343a824cbb36678751bf12e9dacf83127f0e9de539db798aea562492d24ac8",
+            "tags": [
+                "gaming",
+                "postal",
+                "fps",
+                "mature",
+                "funny"
+            ],
+            "preview_sounds": [
+                "dude_map_anddone.mp3",
+                "dude_map_missionaccom.mp3",
+                "dude_oops.mp3"
+            ],
+            "added": "2026-07-30",
+            "updated": "2026-07-30"
+        },
+        {
+            "name": "postal-dude-clean",
+            "display_name": "Postal Dude (POSTAL 2) - Clean",
+            "version": "1.0.0",
+            "description": "The Postal Dude from POSTAL 2 reacts to your coding session. Profanity-free cut.",
+            "author": {
+                "name": "dmonteoliva",
+                "github": "dmonteoliva"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 54,
+            "total_size_bytes": 984564,
+            "source_repo": "dmonteoliva/openpeon-postal-dude",
+            "source_ref": "v1.0.0",
+            "source_path": "postal-dude-clean",
+            "manifest_sha256": "aa9ce39175cd5a4c203bc9cacf8de9673b7f6be922c6d9c677113bca298a0b50",
+            "tags": [
+                "gaming",
+                "postal",
+                "fps",
+                "funny",
+                "clean"
+            ],
+            "preview_sounds": [
+                "dude_map_anddone.mp3",
+                "dude_sweet.mp3",
+                "dude_oops.mp3"
+            ],
+            "added": "2026-07-30",
+            "updated": "2026-07-30"
+        },
+        {
             "name": "postal2_pl",
             "display_name": "Postal 2 (Polish)",
             "version": "1.0.1",


### PR DESCRIPTION
Adds two POSTAL 2 Postal Dude packs. They share one source repo, distinguished by `source_path`, and are pinned to the same `v1.0.0` tag.

| Pack | Clips | Size | Notes |
|---|---:|---:|---|
| `postal-dude` | 62 | ~1.1 MB | Uncensored |
| `postal-dude-clean` | 54 | ~961 KB | Profanity removed |

Both cover all 9 CESP v1.0 categories, including `session.end` and `task.progress` — included for forward compatibility, since peon-ping currently routes neither.

**Source:** https://github.com/dmonteoliva/openpeon-postal-dude @ `v1.0.0`

### Checklist

- [x] Entries sorted alphabetically by `name` (between `posh-gent` and `postal2_pl`)
- [x] `trust_tier` set to `community`
- [x] `manifest_sha256` verified against the files served at the `v1.0.0` tag
- [x] MP3 only; no file exceeds 1 MB; each pack well under the 50 MB cap
- [x] Icon is 256x256 PNG, ~105 KB (under the 500 KB cap)
- [x] Source repo is public
- [x] `total_packs` bumped 350 -> 352
- [x] `tests/` pass locally (43 tests)

`quality` was left off both entries, since it appears to be backfilled by your automation rather than supplied by contributors.

### Content note

`postal-dude` is tagged `mature` and contains profanity, consistent with existing entries such as `postal2_pl` and `duke_nukem`. `postal-dude-clean` is provided for anyone who wants the same pack without it. Happy to adjust if that reads differently against the "no offensive content" rule.

Audio is short excerpts of POSTAL 2 dialogue, loudness-normalised and re-encoded, redistributed non-commercially under CC BY-NC 4.0 covering the curation and manifests only; the recordings remain the property of Running With Scissors, Inc. Each pack ships a `LICENSE` stating that scope.