### PR TITLE
Add mj-grunts community pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -6483,6 +6483,45 @@
             "quality": "gold"
         },
         {
+            "name": "mj-grunts",
+            "display_name": "Michael Jackson Grunts",
+            "version": "1.0.0",
+            "description": "Loud vocal grunts and ad-libs, assigned at random across all events",
+            "author": {
+                "name": "nivaldo",
+                "github": "nivaldomcj"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 18,
+            "total_size_bytes": 448554,
+            "source_repo": "nivaldomcj/openpeon-mj-grunts",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "868e2426e5fed57929652bfffe5296c4ee39fafd5fe1c810409c1279afc0fa4a",
+            "tags": [
+                "music",
+                "vocal",
+                "grunts"
+            ],
+            "preview_sounds": [
+                "mj084.mp3",
+                "mj010.mp3"
+            ],
+            "added": "2026-07-31",
+            "updated": "2026-07-31"
+        },
+        {
             "name": "modern-varied",
             "display_name": "Modern GUI",
             "version": "1.0.1",
@@ -14438,5 +14477,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 350
+    "total_packs": 351
 }


### PR DESCRIPTION
Adds the **Michael Jackson Grunts** community pack — short vocal grunts and ad-libs mapped across the CESP event lifecycle.

- **18 clips** covering **all 7 configured categories**. Assignment is deliberately non-semantic: these are all grunts, so clips are shuffled and dealt evenly across events (3 each for `session.start`, `task.acknowledge`, `task.complete`, `task.error`; 2 each for `input.required`, `resource.limit`, `user.spam`) rather than matched to event meaning.
- **Source:** [nivaldomcj/openpeon-mj-grunts](https://github.com/nivaldomcj/openpeon-mj-grunts) @ `v1.0.0`
- **trust_tier:** community · **license:** fair-use (short excerpts; no ownership claimed, rights remain with the respective rights holders) · **language:** en
- Clips were segmented automatically via `ffmpeg silencedetect`, deduplicated by MFCC cosine distance, then gated on loudness (RMS >= -40 dB) and spectral flatness (<= 0.06) to drop breaths and broadband noise.
- Entry validates against `schema/registry-v1.schema.json` (`$defs/pack`); inserted in alpha order between `mizuki` and `modern-varied`; `quality` field omitted (CI-owned).

### Pre-flight (ran the CI gates locally)
- **Schema:** valid — all 9 required keys present, no keys outside `properties` (`additionalProperties: false`).
- **Ordering:** alphabetical order preserved across all 351 entries; no duplicate names.
- **Manifest hash:** `868e2426…` verified byte-for-byte against the tagged `openpeon.json` fetched from the public raw URL at `v1.0.0`.
- **Audio limits:** 18 files, 448554 bytes total, largest single file 81261 bytes (well under the 1 MB / 50 MB caps); MP3 only.
- **Tests:** `python3 -m unittest discover tests` — 43 passed.
- **total_packs:** bumped 350 → 351 to match `len(packs)`; it was lagging by one before this PR, happy to drop that hunk if you'd rather handle it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)