### PR TITLE
Add dawnlight: a calm, wordless pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -2385,6 +2385,47 @@
             "quality": "silver"
         },
         {
+            "name": "dawnlight",
+            "display_name": "Dawnlight",
+            "version": "1.0.0",
+            "description": "Calm, wordless morning sounds. Warm felt piano and glass chimes, soft attacks and long decays. Every notification is a quiet exhale.",
+            "author": {
+                "name": "Gary Sheng",
+                "github": "garysheng"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 7,
+            "total_size_bytes": 1501555,
+            "source_repo": "garysheng/dawnlight",
+            "source_ref": "v1.0.0",
+            "source_path": "",
+            "manifest_sha256": "357e33d4dca4cd5aea78fadf6056c2a70a0417ef68666c8ab245acff2c044b92",
+            "tags": [
+                "ambient",
+                "calm",
+                "instrumental",
+                "wordless"
+            ],
+            "preview_sounds": [
+                "sounds/task_complete_0.wav",
+                "sounds/session_start_0.wav"
+            ],
+            "added": "2026-08-09",
+            "updated": "2026-08-09",
+            "quality": "gold"
+        },
+        {
             "name": "deadlock_dynamo",
             "display_name": "Dynamo (Deadlock)",
             "version": "1.0.0",

--- a/index.json
+++ b/index.json
@@ -2409,7 +2409,7 @@
             "total_size_bytes": 1501555,
             "source_repo": "garysheng/dawnlight",
             "source_ref": "v1.0.0",
-            "source_path": "",
+            "source_path": ".",
             "manifest_sha256": "357e33d4dca4cd5aea78fadf6056c2a70a0417ef68666c8ab245acff2c044b92",
             "tags": [
                 "ambient",
@@ -2422,8 +2422,7 @@
                 "sounds/session_start_0.wav"
             ],
             "added": "2026-08-09",
-            "updated": "2026-08-09",
-            "quality": "gold"
+            "updated": "2026-08-09"
         },
         {
             "name": "deadlock_dynamo",


### PR DESCRIPTION
Adds [`garysheng/dawnlight`](https://github.com/garysheng/dawnlight) to the registry.

**Dawnlight** is a calm, wordless pack: warm felt piano and glass chimes, soft attacks and long decays, nothing percussive. Built for people who want their agent audible without being interrupted by it. 7 sounds, all 7 CESP categories, CC-BY-NC-4.0.

Notable because it is the first pack authored end to end through the eval gate shipped in peon-ping v2.36.0 (`peon create` then `peon eval`), which does not let a pack exist until a human has listened to every sound and approved it. Two sounds were rerolled during that session from plain-language notes.

The repo ships `prompts.json` (the generation prompt behind each sound) and `eval-log.json` (what changed and why, including the captions that triggered each reroll), so the pack is remixable rather than a dead end: `peon eval dawnlight` re-opens it.

Entry validates against `schema/registry-v1.schema.json` with zero errors. `total_packs` bumped 350 -> 351. No existing entries were modified (verified by parsed comparison; the deletions in the diff are hunk alignment only).