### PR TITLE
Add ua-memes — Ukrainian meme sound pack (74 clips)

### DIFF
--- a/index.json
+++ b/index.json
@@ -12799,6 +12799,48 @@
             "quality": "silver"
         },
         {
+            "name": "ua-memes",
+            "display_name": "Українські меми",
+            "version": "1.0.0",
+            "description": "Ukrainian internet and political meme sounds mapped to coding events. Viral catchphrases, TV gaffes and soundboard classics. Curated third-party clips — no ownership claimed, see ATTRIBUTION.md. Personal, non-commercial use.",
+            "author": {
+                "name": "canya145",
+                "github": "canya145"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "input.required",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "resource.limit",
+                "user.spam"
+            ],
+            "language": "uk",
+            "license": "fair-use",
+            "sound_count": 74,
+            "total_size_bytes": 30011654,
+            "source_repo": "canya145/peonping-ua-memes",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "976725643faacf474df44eaa5eba60d643f60c603ccaa81a9bad77d7b5ad0bf6",
+            "tags": [
+                "ukrainian",
+                "memes",
+                "viral",
+                "soundboard",
+                "uk"
+            ],
+            "preview_sounds": [
+                "Що-ви-зараз-бачите-перед-собою-Це-скарб.wav",
+                "Батя-я-стараюсь.wav",
+                "Dont-push-the-horses.wav"
+            ],
+            "added": "2026-08-19",
+            "updated": "2026-08-19"
+        },
+        {
             "name": "vegeta_dbz",
             "display_name": "Vegeta (Dragon Ball Z)",
             "version": "1.0.0",
@@ -14438,5 +14480,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 350
+    "total_packs": 351
 }

--- a/index.json
+++ b/index.json
@@ -12801,8 +12801,8 @@
         {
             "name": "ua-memes",
             "display_name": "Українські меми",
-            "version": "1.0.0",
-            "description": "Ukrainian internet and political meme sounds mapped to coding events. Viral catchphrases, TV gaffes and soundboard classics. Curated third-party clips — no ownership claimed, see ATTRIBUTION.md. Personal, non-commercial use.",
+            "version": "1.0.1",
+            "description": "Ukrainian internet and political meme sounds mapped to coding events. Viral catchphrases, TV gaffes and soundboard classics. Contains strong language. Curated third-party clips — no ownership claimed, see ATTRIBUTION.md. Personal, non-commercial use.",
             "author": {
                 "name": "canya145",
                 "github": "canya145"
@@ -12820,21 +12820,23 @@
             "language": "uk",
             "license": "fair-use",
             "sound_count": 74,
-            "total_size_bytes": 30011654,
+            "total_size_bytes": 28752230,
             "source_repo": "canya145/peonping-ua-memes",
-            "source_ref": "v1.0.0",
+            "source_ref": "v1.0.1",
             "source_path": ".",
-            "manifest_sha256": "976725643faacf474df44eaa5eba60d643f60c603ccaa81a9bad77d7b5ad0bf6",
+            "manifest_sha256": "9d93e37fe1d6921c1f4ed4bb938f977721a4dcd60477581772a475e7d2a15032",
             "tags": [
                 "ukrainian",
                 "memes",
                 "viral",
                 "soundboard",
+                "nsfw",
+                "mature",
                 "uk"
             ],
             "preview_sounds": [
-                "Що-ви-зараз-бачите-перед-собою-Це-скарб.wav",
-                "Батя-я-стараюсь.wav",
+                "Shcho-vy-zaraz-bachyte-pered-soboiu-Tse-skarb.wav",
+                "Batia-ya-staraius.wav",
                 "Dont-push-the-horses.wav"
             ],
             "added": "2026-08-19",


### PR DESCRIPTION
Adds `ua-memes`, a Ukrainian-language pack of 74 clips covering all seven CESP categories.

**Repo:** https://github.com/canya145/peonping-ua-memes @ `v1.0.0`

### What it is
Ukrainian internet and political meme sounds — viral catchphrases, television gaffes and soundboard classics — mapped to coding events. As far as I can tell this would be the first Ukrainian-language pack in the registry; `stalker_ua` is game voice lines rather than Ukrainian meme culture.

| Clips | Category |
|---:|---|
| 18 | `input.required` |
| 13 | `task.acknowledge` |
| 11 | `task.error` |
| 10 | `task.complete` |
| 9 | `session.start` |
| 7 | `user.spam` |
| 6 | `resource.limit` |

### Notes
- Every clip carries an English meaning-label in `openpeon.json`, so clients that score clips by meaning fit the clip to the moment rather than picking at random.
- Audio is 48 kHz mono WAV, loudness-matched to −16 LUFS / −1.5 dBTP, so nothing jumps in volume between clips.
- `license: fair-use`. The clips are short excerpts of third-party recordings — Ukrainian broadcasts, viral clips and community soundboards. No ownership is claimed; the pack ships `README`, `LICENSE` and an `ATTRIBUTION.md` documenting all 74 clips individually with what is said and where it came from, plus a takedown-on-request notice.

### Diff
Single insertion, alphabetical between `tywin-lannister` and `vegeta_dbz`, plus the `total_packs` bump. No other entries touched — including the existing indentation quirk on `ferdinand-von-aegir`, which I left exactly as-is.