### PR TITLE
Add simlish pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -10642,7 +10642,7 @@
         {
             "name": "simlish",
             "display_name": "Simlish",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "description": "An unofficial fan-made Simlish sound pack for coding events.",
             "author": {
                 "name": "pwillia7",
@@ -10665,9 +10665,9 @@
             "sound_count": 22,
             "total_size_bytes": 372685,
             "source_repo": "pwillia7/openpeon-simlish",
-            "source_ref": "v0.3.0",
+            "source_ref": "v0.3.1",
             "source_path": ".",
-            "manifest_sha256": "34a199ab5089398c1d0f70247d8cab4b65a731c35d01ee2a458361ca53a4d715",
+            "manifest_sha256": "ac59ed2fa9d2b14d6e333a09aafbdcd6c9f4c96a63cb85e81c6970fc9ded7046",
             "tags": [
                 "gaming",
                 "the-sims",

--- a/index.json
+++ b/index.json
@@ -10640,6 +10640,49 @@
             "quality": "silver"
         },
         {
+            "name": "simlish",
+            "display_name": "Simlish",
+            "version": "0.3.0",
+            "description": "An unofficial fan-made Simlish sound pack for coding events.",
+            "author": {
+                "name": "pwillia7",
+                "github": "pwillia7"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.end",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "task.progress",
+                "user.spam"
+            ],
+            "language": "en",
+            "license": "fair-use",
+            "sound_count": 22,
+            "total_size_bytes": 372685,
+            "source_repo": "pwillia7/openpeon-simlish",
+            "source_ref": "v0.3.0",
+            "source_path": ".",
+            "manifest_sha256": "34a199ab5089398c1d0f70247d8cab4b65a731c35d01ee2a458361ca53a4d715",
+            "tags": [
+                "gaming",
+                "the-sims",
+                "simlish",
+                "voice",
+                "fan-made"
+            ],
+            "preview_sounds": [
+                "sul-sul-female.mp3",
+                "simlish-happy-male.mp3"
+            ],
+            "added": "2026-08-20",
+            "updated": "2026-08-20"
+        },
+        {
             "name": "simpsons",
             "display_name": "The Simpsons",
             "version": "1.0.0",


### PR DESCRIPTION
Adds **Simlish** — an unofficial fan-made Simlish sound pack for coding events, built from The Sims voice assets.

Pack repo: https://github.com/pwillia7/openpeon-simlish (tag `v0.3.1`)

## What it is

22 clips, 19 of them spoken Simlish, covering **all nine CESP v1.0 categories**:

- Six directly-extracted Sims 3 "Sul Sul" greetings (three female voices, three male) for `session.start`. The greetings double as short upbeat acknowledgements, so `task.acknowledge` and `input.required` borrow them too.
- Twelve Sims 3 Mobile voice clips in conversational, happy, and irritated registers across both voices.
- A "Dag Dag" farewell for `session.end`.
- Two Sims 3 Mobile UI stings rounding out `task.complete`.

Clips run 0.6–4.0 s. Every clip is loudness-matched to −20.4 LUFS with a −1.5 dBTP ceiling (linear gain only, no compression or EQ), giving a pack loudness spread of **0.1 LU**.

## Naming honesty

Only the Sul Sul clips are labelled with a Simlish phrase, because that is the only phrase we verified against an extracted game asset. The Sims 3 Mobile asset names describe the situation (`convo`, `happy`, `angry`), not the words, so those clips are labelled by register rather than given invented transcriptions like "Vadish" or "Yibs". The stings are labelled as non-verbal. Full provenance, with source pages for every file, is in [SOURCES.md](https://github.com/pwillia7/openpeon-simlish/blob/main/SOURCES.md).

**One clip is weaker than the rest and I'd rather flag it than have you find it.** `dag-dag.mp3` is not a game-file rip like everything else — it was captured with `yt-dlp` from [a YouTube video of Sims 4 gameplay](https://www.youtube.com/watch?v=QZNBgpNbvG4). So it is a screen recording rather than an extracted asset, it is Sims 4 where the rest of the pack is Sims 3, and the "Dag Dag" identification rests on the uploader's video title rather than our own verification. It also carries background noise from that recording which no filtering removed. It is documented as such in `SOURCES.md` and replacing it with a Sims 3 asset rip is the top item in `TODO_AUDIO.md`. Happy to drop `session.end` from this submission instead if you'd prefer the pack hold a consistent provenance bar.

## Checks run locally

- `openpeon.json` validates against `spec/openpeon.schema.json` (CESP v1.0)
- This entry validates against `schema/registry-v1.schema.json`; the diff is additive only and introduces no new schema errors to `index.json`
- All 22 files are `audio/mpeg`, largest 46 KB, 372,685 bytes total
- Every manifest `sha256` verified against the files served at tag `v0.3.1`
- `.github/scripts/quality-check.py` → **GOLD**, 0 blocks, 0 warnings

## Licensing

`license` is `fair-use`, following the convention already used by ~100 packs here. This is commercial game audio; the pack claims no ownership of it and asserts no licence over it, and there is deliberately no `LICENSE` file since there is nothing to reproduce. `SOURCES.md` carries the EA/Maxis non-affiliation disclaimer and a takedown contact.

## Note on CI

The `validate` check fails before reaching this entry: `actions/checkout@v4` refuses to check out fork code under `pull_request_target`, so `index.json` is never present and every validation step is skipped. That affects all current fork PRs, not just this one — see #346, with a proposed fix in #347.
