### PR TITLE
Fix fork PR validation under pull_request_target

### DIFF
--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -14,10 +14,18 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
+      # Check out the BASE repo, not the PR head: this workflow runs under
+      # pull_request_target with contents/pull-requests write, so the scripts it
+      # executes must stay trusted. actions/checkout now refuses a fork head here.
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      # The PR's index.json is data, not code — fetch just that one file.
+      - name: Fetch index.json from the PR
+        run: |
+          git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
+          git show pr-head:index.json > index.json
 
       - name: Validate index.json schema
         id: schema

--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Fetch index.json from the PR
         run: |
           git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
-          git show pr-head:index.json > index.json
+          git show pr-head:index.json > /tmp/pr-index.json
 
       - name: Validate index.json schema
         id: schema

--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -21,11 +21,16 @@ jobs:
         with:
           fetch-depth: 0
 
-      # The PR's index.json is data, not code — fetch just that one file.
+      # The PR's index.json is data, not code, so fetch just that one file and
+      # write it over the base copy so every validation step below reads the
+      # PR's index. Writing it anywhere else leaves the validators looking at
+      # main, where they would find no new packs and pass without checking the
+      # submission. `git show origin/main:index.json`, which "Detect
+      # new/changed packs" diffs against, still resolves through the ref.
       - name: Fetch index.json from the PR
         run: |
           git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
-          git show pr-head:index.json > /tmp/pr-index.json
+          git show pr-head:index.json > index.json
 
       - name: Validate index.json schema
         id: schema


### PR DESCRIPTION
Fixes #346.

## The problem

`actions/checkout@v4` now refuses to check out a fork's head under `pull_request_target`, so `index.json` never lands on disk. *Detect new/changed packs* dies with `FileNotFoundError`, and schema/trust-tier/source/coverage/audio validation are all skipped. Every open fork PR is affected going back to #340 (2026-07-31), including #341 from the org.

## The change

Check out the base repo instead of the fork head, then fetch only the PR's `index.json` — the one thing the job actually needs from the fork, and data rather than code.

```diff
+      - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+
+      - name: Fetch index.json from the PR
+        run: |
+          git fetch --no-tags origin "pull/${{ github.event.pull_request.number }}/head:pr-head"
+          git show pr-head:index.json > index.json
```

Nine lines, one file, no behaviour change to any validation step.

I avoided `allow-unsafe-pr-checkout: true` deliberately. This job holds `contents: write` and `pull-requests: write` and runs `.github/scripts/quality-check.py` from the checkout — with a fork head, a PR could rewrite that script and have it execute with those permissions. Keeping the base checkout means the scripts are always the trusted copy, which is the property the new default is protecting.

## What I verified

Simulated the runner's steps against this repo and PR #345:

- `git fetch --no-tags origin pull/345/head:pr-head` then `git show pr-head:index.json > index.json` produces the PR's index — 351 packs, including the one that PR adds.
- `git show origin/main:index.json`, which *Validate index.json schema* and *Detect new/changed packs* both rely on, still resolves to the 350-pack base. That works because the base checkout is `main` with `fetch-depth: 0`.
- The workflow YAML still parses; 15 steps, unchanged order.

## What I could not verify

The workflow has `paths: ['index.json']`, so this PR won't trigger it, and `pull_request_target` behaviour can only really be exercised from the base repo. **The git mechanics are tested; the workflow wiring is not.** Worth a look from someone who can run it on base before trusting it.

## Disclosure

I have an open pack submission (#345) that is blocked by this, so I'm not a disinterested party, and a fork PR editing workflow checkout logic is exactly the shape of thing worth reading closely — doubly so given the subject. The diff is deliberately minimal so it's quick to audit. Entirely understandable if you'd rather apply the change yourselves and close this; the issue has the same content.
