### PR TITLE
Add atla — Avatar: The Last Airbender

### DIFF
--- a/index.json
+++ b/index.json
@@ -1361,8 +1361,7 @@
                 "water-earth-fire-air.mp3"
             ],
             "added": "2026-08-25",
-            "updated": "2026-08-25",
-            "quality": "gold"
+            "updated": "2026-08-25"
         },
         {
             "name": "balatro",

--- a/index.json
+++ b/index.json
@@ -1320,6 +1320,51 @@
             "quality": "gold"
         },
         {
+            "name": "atla",
+            "display_name": "Avatar: The Last Airbender",
+            "version": "1.0.0",
+            "description": "Catchphrases and iconic moments from Avatar: The Last Airbender.",
+            "author": {
+                "name": "Idan Silbinger",
+                "github": "IdanSil"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "input.required",
+                "resource.limit",
+                "user.spam",
+                "session.end",
+                "task.progress"
+            ],
+            "language": "en",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 36,
+            "total_size_bytes": 1963311,
+            "source_repo": "IdanSil/atla-peon-ping",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "396460581bb502fd3cc712b4e47f3203d00d88ad2972ef7336ce8be61f842000",
+            "tags": [
+                "avatar",
+                "atla",
+                "cartoon",
+                "nickelodeon",
+                "aang",
+                "iroh"
+            ],
+            "preview_sounds": [
+                "my-cabbages.mp3",
+                "water-earth-fire-air.mp3"
+            ],
+            "added": "2026-08-25",
+            "updated": "2026-08-25",
+            "quality": "gold"
+        },
+        {
             "name": "balatro",
             "display_name": "Balatro",
             "version": "1.0.1",
@@ -14438,5 +14483,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 350
+    "total_packs": 351
 }


### PR DESCRIPTION
Adds `atla`, a 36-clip peon-ping pack built from *Avatar: The Last Airbender* — Katara's opening narration, the cabbage merchant's despair, Iroh's tea-shop wisdom, Toph's boasts, and the rest of Team Avatar, mapped across all nine CESP categories.

**Coverage** — session.start, task.acknowledge, task.complete, task.error, input.required, resource.limit, user.spam, session.end, task.progress. Every category has at least one clip, including wordless bending whooshes for `task.progress`.

**Anchor line** for `task.error`: **"MY CABBAGES!"** — the single most load-bearing scream in the franchise, now doing double duty as your test-suite failure sound.

**Sourcing** — every clip was wording-verified against a transcript of its actual source audio before cutting, not just trusted from a video title or soundboard label, so the lines and speaker attributions in the manifest match what's really being said.

**License** — CC-BY-NC-4.0, the same terms used by the other rip-based packs already in the ecosystem (GLaDOS, Rick Sanchez, Tony Soprano, Kerrigan).

Source repo: https://github.com/IdanSil/atla-peon-ping (tag `v1.0.0`)