### PR TITLE
fix(peasant_fr): repoint at og-packs v1.5.0, where the labels match the audio

### DIFF
--- a/index.json
+++ b/index.json
@@ -7681,7 +7681,7 @@
         {
             "name": "peasant_fr",
             "display_name": "Paysan Humain (FR)",
-            "version": "1.0.0",
+            "version": "1.2.0",
             "description": "Paysan Humain (FR) sound pack from Warcraft III",
             "author": {
                 "name": "thomasKn",
@@ -7702,9 +7702,9 @@
             "sound_count": 25,
             "total_size_bytes": 1580126,
             "source_repo": "PeonPing/og-packs",
-            "source_ref": "v1.0.0",
+            "source_ref": "v1.5.0",
             "source_path": "peasant_fr",
-            "manifest_sha256": "2662c8df5d454b554e1541b4a441d58f1620e9665a8a15388a07720e89ed31f6",
+            "manifest_sha256": "cf49713a9a0d708051a90b0dc7db63b96ccc4e065729ae8e2853de8c97aba06f",
             "tags": [
                 "gaming",
                 "warcraft",
@@ -7716,7 +7716,7 @@
                 "PeasantReady1.wav"
             ],
             "added": "2026-02-12",
-            "updated": "2026-02-12",
+            "updated": "2026-08-26",
             "quality": "gold"
         },
         {


### PR DESCRIPTION
Fixes the registry half of PeonPing/peon-ping#577.

The reporter said the `peasant_fr` labels do not match what the clips actually say. Every claim reproduces. I transcribed all 20 wavs and 19 labels were wrong.

The cause: the labels were written by translating the English peasant lines rather than by listening to the French audio. That works for the straightforward ones and fails completely on `PeasantPissed`, where the French localization replaced the Monty Python jokes with its own rather than translating them. The pack advertised "On a trouvé une sorcière ! On peut la brûler ?" and plays "Il est beau. C'est un champion du monde."

The audio is correct and untouched. Only the labels changed.

Separately, `task.complete` referenced `sounds/JobDone.wav`, which does not exist. The file is `sounds/PeasantJobDone.wav`. I audited all 54 og-packs and `peasant_fr` was the only one with a broken file reference.

Fixed in og-packs `5d1245f`, tagged `v1.5.0`. This bumps the registry entry to `version 1.2.0` / `source_ref v1.5.0` with the new manifest hash, verified against the published tag. `sound_count` stays 25 and `quality` stays as CI set it.