### PR TITLE
fix(ci): resolve the trust tier gate from repo permission, not author_association

### DIFF
--- a/.github/workflows/validate-index.yml
+++ b/.github/workflows/validate-index.yml
@@ -202,7 +202,35 @@ jobs:
           association = os.environ.get('PR_AUTHOR_ASSOCIATION', '')
           author_login = os.environ.get('PR_AUTHOR_LOGIN', '')
           token = os.environ.get('GITHUB_TOKEN', '')
-          is_org_member = association in ('OWNER', 'MEMBER')
+          repo_full = os.environ.get('GITHUB_REPOSITORY', '')
+
+          def has_write_access(login):
+              """Ask the API whether this login can actually write to this repo.
+
+              The event payload's author_association is not a reliable answer.
+              GitHub reports CONTRIBUTOR, not MEMBER, for an org member whose
+              membership is private, so a maintainer editing an official pack
+              was rejected on their own repo. Repo permission is the property
+              the tier gate actually means, and it is visible to GITHUB_TOKEN
+              without any org scope.
+              """
+              if not (login and repo_full and token):
+                  return False
+              try:
+                  req = urllib.request.Request(
+                      f'https://api.github.com/repos/{repo_full}/collaborators/{login}/permission')
+                  req.add_header('Authorization', f'token {token}')
+                  req.add_header('Accept', 'application/vnd.github+json')
+                  with urllib.request.urlopen(req) as resp:
+                      perm = json.loads(resp.read()).get('permission', '')
+                  print(f'Author {login}: repo permission {perm or "none"}')
+                  return perm in ('admin', 'write', 'maintain')
+              except (urllib.error.URLError, KeyError, ValueError) as e:
+                  # Fail closed: an unanswerable question is not a yes.
+                  print(f'Warning: could not resolve repo permission for {login}: {e}')
+                  return False
+
+          is_org_member = association in ('OWNER', 'MEMBER') or has_write_access(author_login)
 
           def check_verified_eligibility(login):
               """Check if user meets verified tier requirements:


### PR DESCRIPTION
The `official` trust tier is gated on `github.event.pull_request.author_association` being `OWNER` or `MEMBER`. That is not a reliable answer to "is this person org staff."

GitHub reports `CONTRIBUTOR`, not `MEMBER`, for an org member whose membership is **private**. #350 hit this: the author is a PeonPing org admin, `GET /orgs/PeonPing/memberships/garysheng` returns `role=admin, state=active`, and the webhook payload said:

```
PR_AUTHOR_ASSOCIATION: CONTRIBUTOR
PR_AUTHOR_LOGIN: garysheng
```

So the gate rejected a maintainer editing an official pack on their own repository:

```
Error: peasant_fr: only PeonPing org members can use trust_tier "official"
```

Repo permission is the property the gate actually means, and `GITHUB_TOKEN` can read it with no org scope, unlike `/orgs/{org}/members`. This adds a `has_write_access()` lookup against `/repos/{repo}/collaborators/{login}/permission`, accepting `admin`, `write`, or `maintain`.

The payload association stays as the fast path, so an outside contributor still resolves with no API call and no added latency on the common case. The lookup fails closed: any error, missing token, or unexpected permission is a no.

This does not widen who can set `official`. It narrows the gate onto the right question. Previously a public org member with no write access to this repo would pass; now they need write access, which is what "org staff" was standing in for.

Splitting this out of #350 because `pull_request_target` runs the workflow from the base branch, so #350 cannot validate itself against its own fix.