### PR TITLE
fix(ci): persist-quality opens a PR instead of pushing to main

### DIFF
--- a/.github/workflows/persist-quality.yml
+++ b/.github/workflows/persist-quality.yml
@@ -154,8 +154,15 @@ jobs:
 
           \`quality\` is a CI-owned field. This PR only writes what the audio grade produced.")"
           echo "Opened $PR_URL"
-          gh pr merge "$PR_URL" --squash --auto --delete-branch || \
-            echo "::warning::Auto-merge could not be enabled; the PR is open for manual merge."
+          # Try auto-merge, but do not rely on it. GitHub does not trigger
+          # workflows for events created by GITHUB_TOKEN, so this PR gets no
+          # `validate` run, and `validate` is a required check. Auto-merge
+          # therefore cannot fire and a maintainer merges the PR. Verified on
+          # PR #353: zero checks, zero workflow runs on its branch.
+          # A PAT in PERSIST_TOKEN would close this gap, at the cost of a
+          # long-lived push-to-main credential in repo secrets.
+          gh pr merge "$PR_URL" --squash --auto --delete-branch 2>/dev/null || \
+            echo "::notice::Auto-merge unavailable (bot PRs get no validate run). $PR_URL is open for a maintainer to merge."
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Trigger openpeon.com rebuild

--- a/.github/workflows/persist-quality.yml
+++ b/.github/workflows/persist-quality.yml
@@ -24,6 +24,7 @@ concurrency:
 # Least privilege: this job only needs to push the quality write-back.
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   persist:
@@ -120,24 +121,41 @@ jobs:
           print(f'index.json valid; {len(data.get("packs", []))} packs, quality values in enum')
           PYEOF
 
-      - name: Commit and push
+      - name: Open a PR with the computed tier(s)
         id: commit
         if: steps.detect.outputs.count != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # This opens a PR rather than pushing to main. main requires the
+          # `validate` status check, and a direct push carries no such check, so
+          # the protected-branch hook declined it and the tier was never written
+          # (KTD2's source of truth silently went stale for a month). A PR gets
+          # its own validate run and auto-merges, which is the same route
+          # backfill-quality already takes for the catalog-wide grade.
           if git diff --quiet index.json; then
             echo "No quality change to persist"
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          BRANCH="quality/persist-${GITHUB_RUN_ID}"
+          git checkout -b "$BRANCH"
           git add index.json
-          git commit -m "chore(quality): persist computed tier(s) [skip ci]"
-          # A concurrent merge may have advanced main; rebase before pushing.
-          git pull --rebase origin main
-          if ! git push origin HEAD:main; then
-            echo "::error::Push to main was rejected. Branch protection likely blocks the bot's direct push. Configure a push bypass for github-actions, or set a PERSIST_TOKEN secret (a PAT with bypass). The job fails rather than silently writing nothing."
-            exit 1
-          fi
+          git commit -m "chore(quality): persist computed tier(s)"
+          git push origin "$BRANCH"
+
+          PR_URL="$(gh pr create --base main --head "$BRANCH" \
+            --title "chore(quality): persist computed tier(s)" \
+            --body "CI-computed quality tiers for the pack(s) that just landed on main.
+
+          Opened by \`persist-quality\` rather than pushed directly: main requires the \`validate\` check and a direct push carries none, so the protected-branch hook rejects it.
+
+          \`quality\` is a CI-owned field. This PR only writes what the audio grade produced.")"
+          echo "Opened $PR_URL"
+          gh pr merge "$PR_URL" --squash --auto --delete-branch || \
+            echo "::warning::Auto-merge could not be enabled; the PR is open for manual merge."
           echo "pushed=true" >> "$GITHUB_OUTPUT"
 
       - name: Trigger openpeon.com rebuild


### PR DESCRIPTION
`persist-quality` has been failing since 2026-07-24. 22 packs on main had no `quality` tier as a result, including all 9 that merged today. Those are now graded via #353.

## Cause

main requires the `validate` status check. `persist-quality` pushed the computed tier straight to main, that commit carried no validate run, and the hook declined it:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
 ! [remote rejected] HEAD -> main (protected branch hook declined)
```

Easy to miss for two reasons: `enforce_admins` is off, so a maintainer pushing to main succeeds where the bot does not, and the failure is in a post-merge workflow nobody watches once their own PR is green. To the workflow's credit it failed loudly rather than writing nothing silently.

## What this PR does, and its known limit

The job now pushes a branch and opens a PR instead of pushing to main.

**It does not fully automate the write.** GitHub does not trigger workflows for events created by `GITHUB_TOKEN`, so a PR this job opens gets no `validate` run, and `validate` is a required check. Auto-merge therefore cannot fire and the PR waits for a maintainer.

This was confirmed on #353, not inferred: that PR had zero checks and its branch had zero workflow runs, and it needed an admin merge.

So this trades a silent month-long staleness for a visible queue of one-click PRs. That is an improvement, not a fix.

## The option that does fully automate it

A PAT in `PERSIST_TOKEN`. A PR opened with a PAT does trigger workflows, so `validate` runs and auto-merge works; the same token could also push directly. The cost is a long-lived push-to-main credential in repo secrets.

Holding this open pending that call, since the two options differ on security posture rather than on correctness.