### PR TITLE
Add jessica-bg — Bulgarian voice pack

### DIFF
--- a/index.json
+++ b/index.json
@@ -5368,6 +5368,47 @@
             "quality": "silver"
         },
         {
+            "name": "jessica-bg",
+            "display_name": "Jessica BG",
+            "version": "1.0.0",
+            "description": "A bright, playful voice cheering you on in Bulgarian.",
+            "author": {
+                "name": "beastafk",
+                "github": "beastafk"
+            },
+            "trust_tier": "community",
+            "categories": [
+                "input.required",
+                "resource.limit",
+                "session.start",
+                "task.acknowledge",
+                "task.complete",
+                "task.error",
+                "user.spam"
+            ],
+            "language": "bg",
+            "license": "CC-BY-NC-4.0",
+            "sound_count": 21,
+            "total_size_bytes": 2461454,
+            "source_repo": "beastafk/openpeon-jessica-bg",
+            "source_ref": "v1.0.0",
+            "source_path": ".",
+            "manifest_sha256": "5c9c12a422d611d7fcf1fcacbcac345a97981414295018b53a80bf8400f1afe7",
+            "tags": [
+                "voice",
+                "bulgarian",
+                "tts",
+                "cheerful",
+                "elevenlabs"
+            ],
+            "preview_sounds": [
+                "session_start_0.wav",
+                "task_complete_0.wav"
+            ],
+            "added": "2026-09-10",
+            "updated": "2026-09-10"
+        },
+        {
             "name": "jon_irenicus",
             "display_name": "Jon Irenicus",
             "version": "1.0.0",
@@ -14918,5 +14959,5 @@
             "quality": "silver"
         }
     ],
-    "total_packs": 352
+    "total_packs": 353
 }


### PR DESCRIPTION
Adds `jessica-bg`, a Bulgarian-language voice pack — the first `bg` pack in the registry.

- 21 clips across all 7 CESP categories, 3 per category (no thin core categories)
- 44.1 kHz mono 16-bit WAV, loudness-normalised to ~-15 dB mean with -1 dB peaks
- 2.46 MB total, largest file 160 KB
- Source: https://github.com/beastafk/openpeon-jessica-bg tagged `v1.0.0`
- Licensed CC-BY-NC-4.0; audio generated with ElevenLabs TTS

`prompts.json` ships with the pack so any line can be re-rendered with your own key.